### PR TITLE
Bump Rust Docker base image to 1.96

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM rust:1.90-alpine AS builder
+FROM rust:1.96-alpine AS builder
 WORKDIR /usr/src/
 # Install required build dependencies
 RUN apk add --no-cache musl-dev pkgconfig openssl-dev openssl-libs-static gcc g++ make


### PR DESCRIPTION
Mechanical bump of the Dockerfile `FROM rust:1.X` base image to `rust:1.96`. No source changes; toolchain bump only.

Part of kj800x/homelab#3.