### PR TITLE
Track builds at check-run level instead of check-suite level

### DIFF
--- a/src/build_status.rs
+++ b/src/build_status.rs
@@ -28,13 +28,29 @@ impl From<Option<String>> for BuildStatus {
 impl BuildStatus {
     pub fn of(status: &str, conclusion: &Option<&str>) -> Self {
         match status {
-            "queued" => BuildStatus::Pending,
-            "completed" => match conclusion {
-                Some("success") => BuildStatus::Success,
-                Some("failure") => BuildStatus::Failure,
-                _ => BuildStatus::None,
-            },
+            // A check that has been requested or is running but hasn't concluded.
+            "queued" | "in_progress" | "waiting" | "requested" | "pending" => BuildStatus::Pending,
+            "completed" => Self::from_conclusion(*conclusion),
             _ => BuildStatus::None,
+        }
+    }
+
+    /// Map a GitHub check-run/check-suite `conclusion` to a build status.
+    ///
+    /// The REST "list check runs for a git ref" endpoint returns runs without a
+    /// separate `status` field, so a missing conclusion means the run is still
+    /// in flight (queued/in_progress) and should be treated as Pending.
+    pub fn from_conclusion(conclusion: Option<&str>) -> Self {
+        match conclusion {
+            None => BuildStatus::Pending,
+            // Treat non-failing terminal conclusions as success so they don't
+            // block deploys (matches GitHub's own green-check rollup).
+            Some("success") | Some("neutral") | Some("skipped") | Some("cancelled")
+            | Some("stale") => BuildStatus::Success,
+            Some("failure") | Some("timed_out") | Some("action_required")
+            | Some("startup_failure") => BuildStatus::Failure,
+            // Unknown/unexpected conclusions: don't block, but don't claim success.
+            Some(_) => BuildStatus::None,
         }
     }
 }

--- a/src/db/git_commit_build.rs
+++ b/src/db/git_commit_build.rs
@@ -12,6 +12,11 @@ pub struct GitCommitBuild {
     pub url: String,
     pub start_time: Option<u64>,
     pub settle_time: Option<u64>,
+    /// GitHub App id that produced this check run (e.g. 15368 for GitHub
+    /// Actions). Nullable: legacy rows and the collapsed legacy-status entry
+    /// have no single app. Lets deploy configs eventually depend on specific
+    /// checks keyed by (app_id, check name).
+    pub app_id: Option<u64>,
 }
 
 impl GitCommitBuild {
@@ -24,6 +29,7 @@ impl GitCommitBuild {
             url: row.get(4)?,
             start_time: row.get::<_, Option<u64>>(5)?,
             settle_time: row.get::<_, Option<u64>>(6)?,
+            app_id: row.get::<_, Option<u64>>(7)?,
         })
     }
 
@@ -32,7 +38,7 @@ impl GitCommitBuild {
         repo_id: &u64,
         conn: &PooledConnection<SqliteConnectionManager>,
     ) -> AppResult<Vec<GitCommitBuild>> {
-        let builds = conn.prepare("SELECT repo_id, commit_id, check_name, status, url, start_time, settle_time FROM git_commit_build WHERE commit_id = ?1 AND repo_id = ?2")?
+        let builds = conn.prepare("SELECT repo_id, commit_id, check_name, status, url, start_time, settle_time, app_id FROM git_commit_build WHERE commit_id = ?1 AND repo_id = ?2")?
           .query_and_then(params![commit_id, repo_id], |row| {
             GitCommitBuild::from_row(row)
           })?
@@ -93,6 +99,8 @@ impl GitCommitBuild {
             url: representative.url.clone(),
             start_time,
             settle_time,
+            // The aggregate spans every check, so it has no single producing app.
+            app_id: None,
         }))
     }
 
@@ -108,8 +116,8 @@ impl GitCommitBuild {
             .map_err(AppError::from)?
             .transpose()?.flatten();
 
-        conn.prepare("INSERT OR REPLACE INTO git_commit_build (repo_id, commit_id, check_name, status, url, start_time, settle_time) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)")?
-            .execute(params![build.repo_id, build.commit_id, build.check_name, build.status, build.url, existing_start_time.or(build.start_time), build.settle_time])?;
+        conn.prepare("INSERT OR REPLACE INTO git_commit_build (repo_id, commit_id, check_name, status, url, start_time, settle_time, app_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)")?
+            .execute(params![build.repo_id, build.commit_id, build.check_name, build.status, build.url, existing_start_time.or(build.start_time), build.settle_time, build.app_id])?;
 
         Ok(Self {
             repo_id: build.repo_id,
@@ -119,7 +127,55 @@ impl GitCommitBuild {
             url: build.url.clone(),
             start_time: existing_start_time.or(build.start_time),
             settle_time: build.settle_time,
+            app_id: build.app_id,
         })
+    }
+
+    /// Make the stored builds for a commit match `builds` exactly.
+    ///
+    /// Upserts every build in `builds`, then deletes any existing rows for the
+    /// commit whose `check_name` is not present in `builds`. This is what makes
+    /// a scan authoritative: stale rows (e.g. an old per-suite phantom that
+    /// GitHub no longer reports, or a check that was removed) are pruned instead
+    /// of lingering and pinning the aggregate.
+    ///
+    /// If `builds` is empty, all rows for the commit are removed.
+    pub fn reconcile_for_commit(
+        repo_id: u64,
+        commit_id: i64,
+        builds: &[GitCommitBuild],
+        conn: &PooledConnection<SqliteConnectionManager>,
+    ) -> AppResult<()> {
+        for build in builds {
+            debug_assert_eq!(build.repo_id, repo_id);
+            debug_assert_eq!(build.commit_id, commit_id);
+            Self::upsert(build, conn)?;
+        }
+
+        if builds.is_empty() {
+            conn.prepare("DELETE FROM git_commit_build WHERE commit_id = ?1 AND repo_id = ?2")?
+                .execute(params![commit_id, repo_id])?;
+            return Ok(());
+        }
+
+        // Delete rows for this commit whose check_name isn't in the kept set.
+        // SQLite's parameter limit is high enough that listing names inline via
+        // carrying-bound placeholders is fine for realistic check counts.
+        let placeholders = vec!["?"; builds.len()].join(", ");
+        let sql = format!(
+            "DELETE FROM git_commit_build \
+             WHERE commit_id = ?1 AND repo_id = ?2 \
+             AND check_name NOT IN ({})",
+            placeholders
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let mut bound: Vec<&dyn rusqlite::ToSql> = vec![&commit_id, &repo_id];
+        for build in builds {
+            bound.push(&build.check_name);
+        }
+        stmt.execute(bound.as_slice())?;
+
+        Ok(())
     }
 
     pub fn update(&self, conn: &PooledConnection<SqliteConnectionManager>) -> AppResult<()> {

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -101,9 +101,13 @@ pub fn migrate(mut conn: PooledConnection<SqliteConnectionManager>) -> AppResult
           );
           CREATE INDEX IF NOT EXISTS idx_deploy_event_name_ts ON deploy_event(name, timestamp);
       "#}),
-        // M::up( indoc! { r#"
-        //     SQL GOES HERE
-        // "#}),
+        // Track the GitHub App that produced each check run, so deploy configs
+        // can eventually depend on specific checks (keyed by app + name) rather
+        // than on all checks. Nullable: legacy rows and the REST scan (whose
+        // typed model omits the app) leave this empty.
+        M::up(indoc! { r#"
+          ALTER TABLE git_commit_build ADD COLUMN app_id INTEGER;
+        "#}),
     ]);
 
     conn.pragma_update_and_check(None, "journal_mode", "WAL", |_| Ok(()))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,7 +225,7 @@ async fn main() -> std::io::Result<()> {
         std::env::var("CLIENT_SECRET").expect("CLIENT_SECRET must be set"),
     );
     webhook_manager.add_handler(DatabaseHandler::new(pool.clone(), octocrabs.clone()));
-    webhook_manager.add_handler(MetricsHandler::new(pool.clone()));
+    webhook_manager.add_handler(MetricsHandler::new());
     webhook_manager.add_handler(ConfigSyncHandler::new(
         pool.clone(),
         client.clone(),

--- a/src/web/bootstrap.rs
+++ b/src/web/bootstrap.rs
@@ -147,20 +147,70 @@ async fn list_commits_for_branch(
     Ok(resp.items)
 }
 
-struct CheckSuiteResult {
+/// One resolved check for a commit, ready to persist as a GitCommitBuild.
+struct CheckResult {
+    /// Stable per-commit key: `run-<id>` for Checks API runs, `legacy-status`
+    /// for the collapsed older Statuses API.
     check_name: String,
     status: String,
+    url: String,
+    start_time: Option<u64>,
+    settle_time: Option<u64>,
+    app_id: Option<u64>,
 }
 
-async fn get_check_suites_for_sha(
+fn datetime_to_millis(dt: Option<chrono::DateTime<chrono::Utc>>) -> Option<u64> {
+    dt.map(|d| d.timestamp_millis())
+        .filter(|ms| *ms >= 0)
+        .map(|ms| ms as u64)
+}
+
+// Minimal shape of the "list check runs for a git ref" response. octocrab's
+// typed `CheckRun` model omits the `app` object (true across 0.46 through the
+// current release), so we deserialize the endpoint ourselves to capture
+// `app.id`. octocrab's `crab.get::<R, _, _>(route, _)` is the intended hook for
+// deserializing into a custom type.
+#[derive(serde::Deserialize)]
+struct ScanCheckRunsResponse {
+    check_runs: Vec<ScanCheckRun>,
+}
+
+#[derive(serde::Deserialize)]
+struct ScanCheckRun {
+    id: u64,
+    conclusion: Option<String>,
+    started_at: Option<chrono::DateTime<chrono::Utc>>,
+    completed_at: Option<chrono::DateTime<chrono::Utc>>,
+    html_url: Option<String>,
+    details_url: Option<String>,
+    app: Option<ScanApp>,
+}
+
+#[derive(serde::Deserialize)]
+struct ScanApp {
+    id: u64,
+}
+
+/// Fetch the build state of a commit from GitHub at the check-RUN level.
+///
+/// We deliberately use check runs (the real units of work) rather than check
+/// suites. GitHub auto-creates a suite for every installed App on each push,
+/// including Apps that never run anything; those empty suites report as
+/// `queued` forever and, if ingested, pin a commit at Pending permanently. The
+/// check-runs endpoint (default `filter=latest`) only returns actual runs and
+/// already collapses re-runs to the latest attempt — which is exactly GitHub's
+/// own green-check rollup.
+async fn get_check_runs_for_sha(
     crab: &Octocrab,
     owner: &str,
     repo: &str,
     sha: &str,
-) -> anyhow::Result<Vec<CheckSuiteResult>> {
+) -> anyhow::Result<Vec<CheckResult>> {
     let mut results = Vec::new();
 
-    // Check the older Statuses API - aggregate as a single pseudo-suite
+    // Older Statuses API: kept as a fallback for third-party tools that still
+    // post commit statuses. GitHub Actions does not use this. Collapsed into a
+    // single entry since legacy statuses carry no per-run identity or timing.
     match crab
         .repos(owner, repo)
         .list_statuses(sha.to_string())
@@ -192,10 +242,13 @@ async fn get_check_suites_for_sha(
                 } else {
                     "None"
                 };
-                // Use "suite-0" as a sentinel for the legacy Statuses API
-                results.push(CheckSuiteResult {
-                    check_name: "suite-0".to_string(),
+                results.push(CheckResult {
+                    check_name: "legacy-status".to_string(),
                     status: status.to_string(),
+                    url: format!("https://github.com/{}/{}/commit/{}/checks", owner, repo, sha),
+                    start_time: None,
+                    settle_time: None,
+                    app_id: None,
                 });
             }
         }
@@ -204,53 +257,42 @@ async fn get_check_suites_for_sha(
         }
     }
 
-    // Check the newer Checks API (used by GitHub Actions and most modern CI)
-    match crab
-        .checks(owner, repo)
-        .list_check_suites_for_git_ref(octocrab::params::repos::Commitish(sha.to_string()))
-        .per_page(100)
-        .send()
-        .await
-    {
+    // Modern Checks API (GitHub Actions and most CI). Deserialized via a custom
+    // type so we can keep `app.id`, which octocrab's typed model drops. The
+    // default `filter=latest` returns one run per check (re-runs collapsed).
+    let route = format!("/repos/{}/{}/commits/{}/check-runs?per_page=100", owner, repo, sha);
+    match crab.get::<ScanCheckRunsResponse, _, ()>(&route, None).await {
         Ok(resp) => {
             log::debug!(
-                "Check suites for {}: found {} suites",
+                "Check runs for {}: found {} runs",
                 &sha[..7],
-                resp.check_suites.len()
+                resp.check_runs.len()
             );
-            for suite in resp.check_suites {
-                log::debug!(
-                    "Check suite for {}: id={}, status={:?}, conclusion={:?}",
-                    &sha[..7],
-                    suite.id,
-                    suite.status,
-                    suite.conclusion
-                );
-                let status = match (suite.status.as_deref(), suite.conclusion.as_deref()) {
-                    (Some("completed"), Some("success")) => "Success",
-                    (Some("completed"), Some("failure" | "timed_out" | "action_required")) => {
-                        "Failure"
-                    }
-                    (Some("queued" | "in_progress"), _) => "Pending",
-                    (Some("completed"), Some("neutral" | "cancelled" | "skipped")) => "Success",
-                    _ => {
-                        log::debug!(
-                            "Unhandled check suite state for {}: status={:?}, conclusion={:?}",
-                            &sha[..7],
-                            suite.status,
-                            suite.conclusion
-                        );
-                        continue;
-                    }
-                };
-                results.push(CheckSuiteResult {
-                    check_name: format!("suite-{}", suite.id),
-                    status: status.to_string(),
+            for run in resp.check_runs {
+                // The list-check-runs payload has no separate status field; a
+                // missing conclusion means the run hasn't finished yet.
+                let status: String =
+                    crate::build_status::BuildStatus::from_conclusion(run.conclusion.as_deref())
+                        .into();
+                let url = run
+                    .html_url
+                    .filter(|u| !u.is_empty())
+                    .or(run.details_url)
+                    .unwrap_or_else(|| {
+                        format!("https://github.com/{}/{}/commit/{}/checks", owner, repo, sha)
+                    });
+                results.push(CheckResult {
+                    check_name: format!("run-{}", run.id),
+                    status,
+                    url,
+                    start_time: datetime_to_millis(run.started_at),
+                    settle_time: datetime_to_millis(run.completed_at),
+                    app_id: run.app.map(|a| a.id),
                 });
             }
         }
         Err(e) => {
-            log::debug!("Failed to fetch check suites for {}: {:?}", &sha[..7], e);
+            log::debug!("Failed to fetch check runs for {}: {:?}", &sha[..7], e);
         }
     }
 
@@ -528,8 +570,9 @@ async fn run_owner_bootstrap_impl(
                                 ));
                             }
 
-                            // Best-effort: fetch check suite statuses
-                            match get_check_suites_for_sha(
+                            // Best-effort: fetch check-run statuses and make the
+                            // stored builds for this commit match GitHub exactly.
+                            match get_check_runs_for_sha(
                                 crab,
                                 &repo.owner_name,
                                 &repo.name,
@@ -537,41 +580,42 @@ async fn run_owner_bootstrap_impl(
                             )
                             .await
                             {
-                                Ok(suites) => {
-                                    for suite in suites {
-                                        let build = GitCommitBuild {
+                                Ok(checks) => {
+                                    let builds: Vec<GitCommitBuild> = checks
+                                        .into_iter()
+                                        .map(|c| GitCommitBuild {
                                             repo_id: repo.id,
                                             commit_id: commit.id,
-                                            check_name: suite.check_name,
-                                            status: suite.status,
-                                            url: format!(
-                                                "https://github.com/{}/{}/commit/{}/checks",
-                                                repo.owner_name, repo.name, commit.sha
-                                            ),
-                                            start_time: None,
-                                            settle_time: None,
-                                        };
-                                        if let Err(e) = GitCommitBuild::upsert(&build, &conn) {
-                                            log::debug!(
-                                                "Bootstrap: upsert build for {} failed: {}",
-                                                commit.sha,
-                                                e
-                                            );
-                                            log_append(format!(
-                                                "repo {}/{}: upsert build for {} failed: {}",
-                                                repo.owner_name, repo.name, commit.sha, e
-                                            ));
-                                        }
+                                            check_name: c.check_name,
+                                            status: c.status,
+                                            url: c.url,
+                                            start_time: c.start_time,
+                                            settle_time: c.settle_time,
+                                            app_id: c.app_id,
+                                        })
+                                        .collect();
+                                    if let Err(e) = GitCommitBuild::reconcile_for_commit(
+                                        repo.id, commit.id, &builds, &conn,
+                                    ) {
+                                        log::debug!(
+                                            "Bootstrap: reconcile builds for {} failed: {}",
+                                            commit.sha,
+                                            e
+                                        );
+                                        log_append(format!(
+                                            "repo {}/{}: reconcile builds for {} failed: {}",
+                                            repo.owner_name, repo.name, commit.sha, e
+                                        ));
                                     }
                                 }
                                 Err(e) => {
                                     log::debug!(
-                                        "Bootstrap: fetch check suites for {} failed: {:?}",
+                                        "Bootstrap: fetch check runs for {} failed: {:?}",
                                         commit.sha,
                                         e
                                     );
                                     log_append(format!(
-                                        "repo {}/{}: fetch check suites for {} failed: {:?}",
+                                        "repo {}/{}: fetch check runs for {} failed: {:?}",
                                         repo.owner_name, repo.name, commit.sha, e
                                     ));
                                 }
@@ -872,34 +916,35 @@ async fn run_repo_bootstrap_impl(
                         );
                     }
 
-                    // Fetch build status for each commit
-                    match get_check_suites_for_sha(crab, &owner, &repo_name, &commit.sha).await {
-                        Ok(suites) => {
-                            for suite in suites {
-                                let build = GitCommitBuild {
+                    // Fetch check runs and reconcile stored builds with GitHub.
+                    match get_check_runs_for_sha(crab, &owner, &repo_name, &commit.sha).await {
+                        Ok(checks) => {
+                            let builds: Vec<GitCommitBuild> = checks
+                                .into_iter()
+                                .map(|c| GitCommitBuild {
                                     repo_id: repo.id,
                                     commit_id: commit.id,
-                                    check_name: suite.check_name,
-                                    status: suite.status,
-                                    url: format!(
-                                        "https://github.com/{}/{}/commit/{}/checks",
-                                        owner, repo_name, commit.sha
-                                    ),
-                                    start_time: None,
-                                    settle_time: None,
-                                };
-                                if let Err(e) = GitCommitBuild::upsert(&build, &conn) {
-                                    log::debug!(
-                                        "Bootstrap: upsert build for {} failed: {}",
-                                        commit.sha,
-                                        e
-                                    );
-                                }
+                                    check_name: c.check_name,
+                                    status: c.status,
+                                    url: c.url,
+                                    start_time: c.start_time,
+                                    settle_time: c.settle_time,
+                                    app_id: c.app_id,
+                                })
+                                .collect();
+                            if let Err(e) = GitCommitBuild::reconcile_for_commit(
+                                repo.id, commit.id, &builds, &conn,
+                            ) {
+                                log::debug!(
+                                    "Bootstrap: reconcile builds for {} failed: {}",
+                                    commit.sha,
+                                    e
+                                );
                             }
                         }
                         Err(e) => {
                             log::debug!(
-                                "Bootstrap: fetch check suites for {} failed: {:?}",
+                                "Bootstrap: fetch check runs for {} failed: {:?}",
                                 commit.sha,
                                 e
                             );
@@ -1172,34 +1217,39 @@ async fn run_repo_resync_impl(
                 );
             }
 
-            // Fetch build status for the commit
-            match get_check_suites_for_sha(crab, &owner, &repo_name, &commit.sha).await {
-                Ok(suites) => {
-                    for suite in suites {
-                        let build = GitCommitBuild {
+            // Fetch check runs and reconcile stored builds with GitHub.
+            match get_check_runs_for_sha(crab, &owner, &repo_name, &commit.sha).await {
+                Ok(checks) => {
+                    let builds: Vec<GitCommitBuild> = checks
+                        .into_iter()
+                        .map(|c| GitCommitBuild {
                             repo_id: repo.id,
                             commit_id: commit.id,
-                            check_name: suite.check_name,
-                            status: suite.status,
-                            url: format!(
-                                "https://github.com/{}/{}/commit/{}/checks",
-                                owner, repo_name, commit.sha
-                            ),
-                            start_time: None,
-                            settle_time: None,
-                        };
-                        if let Err(e) = GitCommitBuild::upsert(&build, &conn) {
-                            log::debug!("Bootstrap: upsert build for {} failed: {}", commit.sha, e);
-                            log_append(format!(
-                                "repo {}/{}: upsert build for {} failed: {}",
-                                owner, repo_name, commit.sha, e
-                            ));
-                        }
+                            check_name: c.check_name,
+                            status: c.status,
+                            url: c.url,
+                            start_time: c.start_time,
+                            settle_time: c.settle_time,
+                            app_id: c.app_id,
+                        })
+                        .collect();
+                    if let Err(e) =
+                        GitCommitBuild::reconcile_for_commit(repo.id, commit.id, &builds, &conn)
+                    {
+                        log::debug!(
+                            "Bootstrap: reconcile builds for {} failed: {}",
+                            commit.sha,
+                            e
+                        );
+                        log_append(format!(
+                            "repo {}/{}: reconcile builds for {} failed: {}",
+                            owner, repo_name, commit.sha, e
+                        ));
                     }
                 }
                 Err(e) => {
                     log::debug!(
-                        "Bootstrap: fetch check suites for {} failed: {:?}",
+                        "Bootstrap: fetch check runs for {} failed: {:?}",
                         commit.sha,
                         e
                     );

--- a/src/webhooks/database.rs
+++ b/src/webhooks/database.rs
@@ -15,8 +15,8 @@ use crate::{
         git_repo::GitRepo,
     },
     webhooks::{
-        models::{CheckRunEvent, CheckSuiteEvent, DeleteEvent, PushEvent},
-        util::extract_branch_name,
+        models::{CheckRunEvent, DeleteEvent, PushEvent},
+        util::{extract_branch_name, rfc3339_to_millis},
         WebhookHandler,
     },
 };
@@ -121,84 +121,52 @@ impl WebhookHandler for DatabaseHandler {
             .get()
             .context("Failed to get database connection")?;
 
-        if payload.action.as_str() == "created" {
-            let build_status = BuildStatus::of(
-                &payload.check_run.check_suite.status,
-                &payload.check_run.check_suite.conclusion.as_deref(),
-            );
+        let run = &payload.check_run;
 
-            let repo: GitRepo = payload.repository.clone().into();
-            repo.upsert(&conn).context("Error upserting repository")?;
+        // We track build state at the check-run level (the actual unit of work),
+        // not the check-suite level. GitHub auto-creates a suite per installed
+        // App on every push even when that App never runs anything (e.g. an
+        // empty "queued" suite with zero runs); keying on suites lets those
+        // phantoms pin a commit at Pending forever. Runs only exist when there
+        // is real work, and they carry their own status/conclusion/timestamps.
+        let build_status = BuildStatus::of(&run.status, &run.conclusion.as_deref());
 
-            let head_commit = GitCommit::get_by_sha(
-                &payload.check_run.check_suite.head_sha.clone(),
-                repo.id,
-                &conn,
-            )
+        let repo: GitRepo = payload.repository.clone().into();
+        repo.upsert(&conn).context("Error upserting repository")?;
+
+        let head_commit = GitCommit::get_by_sha(&run.check_suite.head_sha, repo.id, &conn)
             .context("Error getting commit")?
             .ok_or(anyhow::Error::msg("Commit not found"))?;
 
-            let check_name = format!("suite-{}", payload.check_run.check_suite.id);
+        let check_name = format!("run-{}", run.id);
 
-            let commit_build = GitCommitBuild {
-                repo_id: repo.id,
-                commit_id: head_commit.id,
-                check_name,
-                status: build_status.into(),
-                url: payload.check_run.details_url.clone(),
-                start_time: Some(Utc::now().timestamp_millis() as u64),
-                settle_time: None,
-            };
-            GitCommitBuild::upsert(&commit_build, &conn).context("Error upserting commit build")?;
-        }
+        let url = run
+            .html_url
+            .clone()
+            .filter(|u| !u.is_empty())
+            .unwrap_or_else(|| run.details_url.clone());
 
-        Ok(())
-    }
-
-    async fn handle_check_suite(&self, payload: CheckSuiteEvent) -> Result<(), anyhow::Error> {
-        log::debug!("Received check suite event:\n{:#?}", payload);
-
-        let conn = self
-            .pool
-            .get()
-            .context("Failed to get database connection")?;
-
-        if payload.action.as_str() == "completed" {
-            let build_status = BuildStatus::of(
-                &payload.check_suite.status,
-                &payload.check_suite.conclusion.as_deref(),
-            );
-
-            let repo: GitRepo = payload.repository.clone().into();
-            repo.upsert(&conn).context("Error upserting repository")?;
-
-            let head_commit =
-                GitCommit::get_by_sha(&payload.check_suite.head_sha.clone(), repo.id, &conn)
-                    .context("Error getting commit")?
-                    .ok_or(anyhow::Error::msg("Commit not found"))?;
-
-            let check_name = format!("suite-{}", payload.check_suite.id);
-
-            let build_url = format!(
-                "https://github.com/{}/{}/commit/{}/checks",
-                payload.repository.owner.login,
-                payload.repository.name,
-                payload.check_suite.head_sha
-            );
-            let commit_build = GitCommitBuild {
-                repo_id: repo.id,
-                commit_id: head_commit.id,
-                check_name,
-                status: build_status.into(),
-                url: build_url,
-                start_time: None,
-                settle_time: Some(Utc::now().timestamp_millis() as u64),
-            };
-            GitCommitBuild::upsert(&commit_build, &conn).context("Error upserting commit build")?;
-        }
+        let commit_build = GitCommitBuild {
+            repo_id: repo.id,
+            commit_id: head_commit.id,
+            check_name,
+            status: build_status.into(),
+            url,
+            // Prefer GitHub's own timestamps; fall back to event-receipt time
+            // for start so an in-flight run still shows elapsed progress.
+            start_time: rfc3339_to_millis(run.started_at.as_deref())
+                .or_else(|| Some(Utc::now().timestamp_millis() as u64)),
+            settle_time: rfc3339_to_millis(run.completed_at.as_deref()),
+            app_id: run.app.as_ref().map(|a| a.id),
+        };
+        GitCommitBuild::upsert(&commit_build, &conn).context("Error upserting commit build")?;
 
         Ok(())
     }
+
+    // check_suite events are intentionally not used to write build rows. Suites
+    // are containers, not units of work, and an empty/abandoned suite would
+    // otherwise mask the real per-run status. See handle_check_run above.
 
     async fn handle_delete(&self, payload: DeleteEvent) -> Result<(), anyhow::Error> {
         log::debug!("Received delete event:\n{:#?}", payload);

--- a/src/webhooks/metrics.rs
+++ b/src/webhooks/metrics.rs
@@ -1,27 +1,21 @@
-use anyhow::Context;
-use chrono::Utc;
 use opentelemetry::KeyValue;
-use r2d2::Pool;
-use r2d2_sqlite::SqliteConnectionManager;
 use serenity::async_trait;
 
 use crate::{
     build_status::BuildStatus,
-    db::{git_commit::GitCommit, git_commit_build::GitCommitBuild, git_repo::GitRepo},
     webhooks::{
-        models::{CheckRunEvent, CheckSuiteEvent, PushEvent},
-        util::extract_branch_name,
+        models::{CheckRunEvent, PushEvent},
+        util::{extract_branch_name, rfc3339_to_millis},
         WebhookHandler,
     },
 };
 
-pub struct MetricsHandler {
-    pool: Pool<SqliteConnectionManager>,
-}
+#[derive(Default)]
+pub struct MetricsHandler {}
 
 impl MetricsHandler {
-    pub fn new(pool: Pool<SqliteConnectionManager>) -> Self {
-        Self { pool }
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 
@@ -51,84 +45,55 @@ impl WebhookHandler for MetricsHandler {
     }
 
     async fn handle_check_run(&self, payload: CheckRunEvent) -> Result<(), anyhow::Error> {
-        if payload.action.as_str() != "created" {
-            return Ok(());
-        }
-
         let repo_label = format!(
             "{}/{}",
             payload.repository.owner.login, payload.repository.name
         );
-        let check_name = format!("suite-{}", payload.check_run.check_suite.id);
-        crate::metrics::get().builds_started.add(
-            1,
-            &[
-                KeyValue::new("repo", repo_label),
-                KeyValue::new("check_name", check_name),
-            ],
-        );
+        let run = &payload.check_run;
+        // Label metrics by the run name (e.g. "build") rather than an opaque,
+        // per-commit suite id. The name is stable across commits, which is what
+        // makes per-check trends (e.g. duration over time) meaningful.
+        let check_name = run.name.clone();
 
-        Ok(())
-    }
-
-    async fn handle_check_suite(&self, payload: CheckSuiteEvent) -> Result<(), anyhow::Error> {
-        if payload.action.as_str() != "completed" {
-            return Ok(());
+        if payload.action.as_str() == "created" {
+            crate::metrics::get().builds_started.add(
+                1,
+                &[
+                    KeyValue::new("repo", repo_label.clone()),
+                    KeyValue::new("check_name", check_name.clone()),
+                ],
+            );
         }
 
-        let repo_label = format!(
-            "{}/{}",
-            payload.repository.owner.login, payload.repository.name
-        );
+        // Resolve metrics fire when the run reaches a terminal state.
+        if run.status.as_str() == "completed" {
+            let status_str: String = BuildStatus::from_conclusion(run.conclusion.as_deref()).into();
 
-        let check_name = format!("suite-{}", payload.check_suite.id);
+            crate::metrics::get().builds_resolved.add(
+                1,
+                &[
+                    KeyValue::new("repo", repo_label.clone()),
+                    KeyValue::new("check_name", check_name.clone()),
+                    KeyValue::new("status", status_str.clone()),
+                ],
+            );
 
-        let build_status = BuildStatus::of(
-            &payload.check_suite.status,
-            &payload.check_suite.conclusion.as_deref(),
-        );
-        let status_str: String = build_status.into();
-
-        crate::metrics::get().builds_resolved.add(
-            1,
-            &[
-                KeyValue::new("repo", repo_label.clone()),
-                KeyValue::new("check_name", check_name.clone()),
-                KeyValue::new("status", status_str.clone()),
-            ],
-        );
-
-        // Look up the build to get start_time for duration calculation.
-        // DatabaseHandler runs first, so the build row is already present.
-        let conn = self
-            .pool
-            .get()
-            .context("Failed to get database connection")?;
-
-        let repo: GitRepo = payload.repository.clone().into();
-
-        let maybe_commit =
-            GitCommit::get_by_sha(&payload.check_suite.head_sha, repo.id, &conn)
-                .context("Error getting commit")?;
-
-        if let Some(commit) = maybe_commit {
-            let builds = GitCommitBuild::get_all_by_commit_id(&commit.id, &repo.id, &conn)
-                .context("Error getting builds")?;
-
-            if let Some(build) = builds.iter().find(|b| b.check_name == check_name) {
-                if let Some(start_time) = build.start_time {
-                    let now_ms = Utc::now().timestamp_millis() as u64;
-                    if now_ms > start_time {
-                        let duration_secs = (now_ms - start_time) as f64 / 1000.0;
-                        crate::metrics::get().build_duration_seconds.record(
-                            duration_secs,
-                            &[
-                                KeyValue::new("repo", repo_label),
-                                KeyValue::new("check_name", check_name),
-                                KeyValue::new("status", status_str),
-                            ],
-                        );
-                    }
+            // Duration straight from GitHub's own timestamps (no DB round-trip
+            // and no dependency on handler ordering).
+            if let (Some(start), Some(end)) = (
+                rfc3339_to_millis(run.started_at.as_deref()),
+                rfc3339_to_millis(run.completed_at.as_deref()),
+            ) {
+                if end > start {
+                    let duration_secs = (end - start) as f64 / 1000.0;
+                    crate::metrics::get().build_duration_seconds.record(
+                        duration_secs,
+                        &[
+                            KeyValue::new("repo", repo_label),
+                            KeyValue::new("check_name", check_name),
+                            KeyValue::new("status", status_str),
+                        ],
+                    );
                 }
             }
         }

--- a/src/webhooks/models.rs
+++ b/src/webhooks/models.rs
@@ -48,8 +48,26 @@ pub struct CheckSuite {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CheckApp {
+    pub id: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CheckRun {
+    pub id: u64,
+    pub name: String,
+    /// queued | in_progress | completed (and occasionally waiting/requested/pending)
+    pub status: String,
+    pub conclusion: Option<String>,
     pub details_url: String,
+    pub html_url: Option<String>,
+    /// RFC3339 timestamp for when the run started, if reported.
+    pub started_at: Option<String>,
+    /// RFC3339 timestamp for when the run completed, if reported.
+    pub completed_at: Option<String>,
+    /// GitHub App that produced this run. Optional for robustness, though the
+    /// webhook payload always includes it.
+    pub app: Option<CheckApp>,
     pub check_suite: CheckSuite,
 }
 

--- a/src/webhooks/util.rs
+++ b/src/webhooks/util.rs
@@ -1,4 +1,16 @@
+use chrono::DateTime;
 use regex::Regex;
+
+/// Parse an optional RFC3339 timestamp (as GitHub returns on check runs) into
+/// epoch milliseconds. Returns None if absent or unparseable.
+pub fn rfc3339_to_millis(ts: Option<&str>) -> Option<u64> {
+    let ts = ts?;
+    DateTime::parse_from_rfc3339(ts)
+        .ok()
+        .map(|dt| dt.timestamp_millis())
+        .filter(|ms| *ms >= 0)
+        .map(|ms| ms as u64)
+}
 
 // FIXME: This can be a method impl on the PushEvent itself
 


### PR DESCRIPTION
## Problem

Build state was keyed on GitHub **check suites** (`suite-<id>` rows). GitHub auto-creates a suite for every installed App on every push — even Apps that never run anything. The `anthropics/claude` App is installed account-wide, so each push opens an empty suite that sits at `status=queued, conclusion=null, latest_check_runs_count=0` **forever**. Ingesting that as `Pending` pinned the commit at Pending permanently.

This surfaced after a CICD outage: various commits (`kj800x/tasker`, `kj800x/cicd`) showed as in-progress while GitHub showed them green. The PR UI correctly showed only the real check ("Docker / build") because it lists check **runs**; the empty Claude suite has zero runs so GitHub hides it — but CICD ingested it at the suite level. The "deep repo scan" re-cemented the phantom because it only upserted and never pruned.

## Fix

Move ingestion to **check runs** — the actual units of work, and what GitHub itself uses for its green-check rollup.

- **`build_status`**: `BuildStatus::of` now treats `in_progress`/`waiting`/`requested` as Pending; new `from_conclusion` (the REST list-check-runs payload has no `status` field, so a missing `conclusion` means still-running → Pending). Conclusion vocabulary broadened (`neutral`/`skipped`/`cancelled`/`stale` → Success; `timed_out`/`action_required`/`startup_failure` → Failure).
- **Webhooks**: `handle_check_run` writes `run-<id>` rows from the run's own status/conclusion and GitHub-native timestamps; processes all actions, not just `created`. The suite-level write is removed. Metrics resolution + duration moved into the run handler, keyed by the stable run **name** (so per-check duration trends are meaningful) and computed from GitHub timestamps (no DB round-trip / handler-ordering dependency).
- **DB**: `GitCommitBuild::reconcile_for_commit` upserts fetched runs and **deletes** rows GitHub no longer reports — making the scan authoritative. Old `suite-*` phantoms get pruned the next time an affected commit is scanned (self-heals; no manual DB surgery).
- **Bootstrap**: all three scan paths fetch check runs (`filter=latest`, so re-runs are already collapsed) instead of suites. Legacy Statuses API kept as a collapsed `legacy-status` fallback for third-party tools.

## Also: per-check `app_id` (prep for deploy-config dependencies)

Stores the producing GitHub App id per run, so deploy configs can eventually depend on specific checks keyed by `(app_id, name)` rather than on *all* checks.

- New nullable `app_id` column on `git_commit_build`.
- Webhook path reads `check_run.app.id` natively.
- Scan path: octocrab's typed `CheckRun` model omits `app` in **every** version (verified 0.46 → `main`), so the scan deserializes the endpoint via `crab.get::<_, _, ()>` into a small local type to capture `app.id` — octocrab's intended extension hook, not a workaround.

## Migration

```sql
ALTER TABLE git_commit_build ADD COLUMN app_id INTEGER;
```

Additive, nullable, **backwards compatible** — existing rows get NULL, nothing is rewritten or dropped. This is the only schema change; the check-run refactor itself needed none (only the meaning of `check_name` changed: `suite-<id>` → `run-<id>`).

**Note:** `app_id` populates for newly-ingested rows (webhook + rescan); pre-existing rows and the `legacy-status` entry stay NULL until their commit is next scanned. The dependency-matching feature should not assume `app_id` is always present.

## Testing

- `cargo build` clean; `cargo clippy` introduces no new warnings (4 remaining are pre-existing in untouched files).
- Diagnosis verified against the live GitHub API (check-suites vs check-runs vs PR UI) for all three stuck commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)