### PR TITLE
Inject CICD_* deploy env vars into deployed containers

### DIFF
--- a/src/kubernetes/controller.rs
+++ b/src/kubernetes/controller.rs
@@ -2,7 +2,7 @@ use super::DeployConfig;
 use crate::error::format_error_chain;
 use crate::kubernetes::api::ListMode;
 use crate::kubernetes::repo::DeploymentState;
-use crate::kubernetes::spec_editing::WithVersion;
+use crate::kubernetes::spec_editing::{WithInjectedEnv, WithVersion};
 use crate::kubernetes::{
     apply, delete_dynamic_object, ensure_namespace_exists, list_namespace_objects,
 };
@@ -41,6 +41,9 @@ async fn reconcile(dc: Arc<DeployConfig>, ctx: Arc<ControllerContext>) -> AppRes
         // Continue anyway - namespace might already exist
     }
 
+    // CICD_* env vars describing this deploy, injected into every container.
+    let deploy_env_vars = dc.deploy_env_vars();
+
     // Create or update resources as needed
     for resource in dc.resource_specs() {
         let mut obj: DynamicObject = serde_json::from_value(resource.clone()).map_err(|e| {
@@ -53,6 +56,8 @@ async fn reconcile(dc: Arc<DeployConfig>, ctx: Arc<ControllerContext>) -> AppRes
         if let DeploymentState::DeployedWithArtifact { artifact, .. } = dc.deployment_state() {
             obj = obj.with_version(&artifact.sha);
         }
+
+        obj = obj.with_injected_env(&deploy_env_vars);
 
         dc.ensure_owner_reference(&mut obj);
         dc.ensure_labels(&mut obj);

--- a/src/kubernetes/deploy_config.rs
+++ b/src/kubernetes/deploy_config.rs
@@ -142,6 +142,70 @@ impl DeployConfig {
         }
     }
 
+    /// Whether this deploy is "non-latest": a branch other than the artifact's
+    /// tracking (default) branch, or a pinned SHA override (no branch).
+    ///
+    /// Consumers use this to fail closed on dangerous actions (e.g. refusing DB
+    /// schema migrations on a branch/pinned deploy).
+    pub fn is_non_latest_deploy(&self) -> bool {
+        match self.deployment_state() {
+            DeploymentState::DeployedWithArtifact { artifact, .. } => {
+                // None (pinned SHA) never equals Some(default), so a pinned
+                // deploy is always non-latest, as is any non-default branch.
+                let default_branch = self.artifact_repository().map(|r| r.branch);
+                artifact.branch.as_deref() != default_branch.as_deref()
+            }
+            // Config-only deploys don't track a config default branch yet, so
+            // they can't be classified as non-latest. Wire this up when config
+            // branch/SHA control lands.
+            DeploymentState::DeployedOnlyConfig { .. } => false,
+            DeploymentState::Undeployed => false,
+        }
+    }
+
+    /// The `CICD_*` environment variables to inject into every container of the
+    /// deployed workloads. Describes the deploy so apps can report their version
+    /// and make deploy-aware decisions (see [`Self::is_non_latest_deploy`]).
+    pub fn deploy_env_vars(&self) -> Vec<(String, String)> {
+        let mut vars: Vec<(String, String)> = vec![
+            ("CICD_DEPLOY_CONFIG".to_string(), self.name_any()),
+            ("CICD_TEAM".to_string(), self.team().to_string()),
+            (
+                "CICD_NON_LATEST_DEPLOY".to_string(),
+                self.is_non_latest_deploy().to_string(),
+            ),
+        ];
+
+        if let Some(default_branch) = self.artifact_repository().map(|r| r.branch) {
+            vars.push(("CICD_DEFAULT_BRANCH".to_string(), default_branch));
+        }
+
+        match self.deployment_state() {
+            DeploymentState::DeployedWithArtifact { artifact, config } => {
+                vars.push(("CICD_ARTIFACT_SHA".to_string(), artifact.sha));
+                vars.push((
+                    "CICD_ARTIFACT_BRANCH".to_string(),
+                    artifact.branch.unwrap_or_default(),
+                ));
+                vars.push(("CICD_CONFIG_SHA".to_string(), config.sha));
+                vars.push((
+                    "CICD_CONFIG_BRANCH".to_string(),
+                    config.branch.unwrap_or_default(),
+                ));
+            }
+            DeploymentState::DeployedOnlyConfig { config } => {
+                vars.push(("CICD_CONFIG_SHA".to_string(), config.sha));
+                vars.push((
+                    "CICD_CONFIG_BRANCH".to_string(),
+                    config.branch.unwrap_or_default(),
+                ));
+            }
+            DeploymentState::Undeployed => {}
+        }
+
+        vars
+    }
+
     /// Returns the owner reference to be applied to child resources
     pub fn child_owner_reference(&self) -> OwnerReference {
         OwnerReference {

--- a/src/kubernetes/spec_editing.rs
+++ b/src/kubernetes/spec_editing.rs
@@ -8,6 +8,97 @@ pub trait WithVersion {
     fn with_version(&self, version: &str) -> Self;
 }
 
+pub trait WithInjectedEnv {
+    /// Upserts the given `(name, value)` environment variables into the `env`
+    /// array of every container found in the spec.
+    fn with_injected_env(&self, vars: &[(String, String)]) -> Self;
+}
+
+/// Upsert a single env var into a container's `env` array (by name), so we never
+/// create duplicate entries and always win over a pre-existing literal value.
+fn upsert_env(env_arr: &mut Vec<serde_json::Value>, name: &str, value: &str) {
+    let existing = env_arr
+        .iter_mut()
+        .find(|e| e.get("name").and_then(|n| n.as_str()) == Some(name));
+
+    match existing {
+        Some(serde_json::Value::Object(obj)) => {
+            obj.insert(
+                "value".to_string(),
+                serde_json::Value::String(value.to_string()),
+            );
+            // Our literal value supersedes any prior valueFrom reference.
+            obj.remove("valueFrom");
+        }
+        _ => {
+            env_arr.push(serde_json::json!({ "name": name, "value": value }));
+        }
+    }
+}
+
+/// Inject env vars into each container object of a `containers`/`initContainers` array.
+fn inject_env_into_containers(
+    containers: &serde_json::Value,
+    vars: &[(String, String)],
+) -> serde_json::Value {
+    let serde_json::Value::Array(arr) = containers else {
+        return containers.clone();
+    };
+
+    let new_arr = arr
+        .iter()
+        .map(|container| {
+            let serde_json::Value::Object(obj) = container else {
+                return container.clone();
+            };
+            let mut obj = obj.clone();
+            let mut env_arr: Vec<serde_json::Value> = match obj.get("env") {
+                Some(serde_json::Value::Array(a)) => a.clone(),
+                _ => Vec::new(),
+            };
+            for (name, value) in vars {
+                upsert_env(&mut env_arr, name, value);
+            }
+            obj.insert("env".to_string(), serde_json::Value::Array(env_arr));
+            serde_json::Value::Object(obj)
+        })
+        .collect();
+
+    serde_json::Value::Array(new_arr)
+}
+
+impl WithInjectedEnv for serde_json::Value {
+    fn with_injected_env(&self, vars: &[(String, String)]) -> Self {
+        match self {
+            serde_json::Value::Object(json) => {
+                let mut new_json = serde_json::Map::new();
+                for (key, value) in json {
+                    let new_value =
+                        if (key == "containers" || key == "initContainers") && value.is_array() {
+                            inject_env_into_containers(value, vars)
+                        } else {
+                            value.with_injected_env(vars)
+                        };
+                    new_json.insert(key.clone(), new_value);
+                }
+                serde_json::Value::Object(new_json)
+            }
+            serde_json::Value::Array(array) => {
+                serde_json::Value::Array(array.iter().map(|v| v.with_injected_env(vars)).collect())
+            }
+            _ => self.clone(),
+        }
+    }
+}
+
+impl WithInjectedEnv for DynamicObject {
+    fn with_injected_env(&self, vars: &[(String, String)]) -> Self {
+        let mut obj = self.clone();
+        obj.data = obj.data.with_injected_env(vars);
+        obj
+    }
+}
+
 impl WithInterpolatedVersion for serde_json::Value {
     fn with_interpolated_version(&self, version: &str) -> Self {
         match self {
@@ -51,5 +142,185 @@ impl WithVersion for DynamicObject {
 
         obj.data = obj.data.with_interpolated_version(version);
         obj
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn vars() -> Vec<(String, String)> {
+        vec![
+            ("CICD_NON_LATEST_DEPLOY".to_string(), "true".to_string()),
+            ("CICD_ARTIFACT_SHA".to_string(), "abc123".to_string()),
+        ]
+    }
+
+    /// Collect the env arrays of all containers/initContainers found anywhere.
+    fn all_env_arrays(value: &serde_json::Value, out: &mut Vec<serde_json::Value>) {
+        match value {
+            serde_json::Value::Object(map) => {
+                for (key, v) in map {
+                    if (key == "containers" || key == "initContainers") && v.is_array() {
+                        for container in v.as_array().into_iter().flatten() {
+                            if let Some(env) = container.get("env") {
+                                out.push(env.clone());
+                            }
+                        }
+                    }
+                    all_env_arrays(v, out);
+                }
+            }
+            serde_json::Value::Array(arr) => {
+                for v in arr {
+                    all_env_arrays(v, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn env_value(env: &serde_json::Value, name: &str) -> Option<String> {
+        env.as_array()?
+            .iter()
+            .find(|e| e.get("name").and_then(|n| n.as_str()) == Some(name))?
+            .get("value")?
+            .as_str()
+            .map(|s| s.to_string())
+    }
+
+    #[test]
+    fn injects_into_deployment_container() {
+        let spec = json!({
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "spec": { "template": { "spec": { "containers": [
+                { "name": "app", "image": "app:latest" }
+            ] } } }
+        });
+
+        let out = spec.with_injected_env(&vars());
+        let mut envs = Vec::new();
+        all_env_arrays(&out, &mut envs);
+
+        assert_eq!(envs.len(), 1);
+        assert_eq!(
+            env_value(&envs[0], "CICD_NON_LATEST_DEPLOY").as_deref(),
+            Some("true")
+        );
+        assert_eq!(
+            env_value(&envs[0], "CICD_ARTIFACT_SHA").as_deref(),
+            Some("abc123")
+        );
+    }
+
+    #[test]
+    fn injects_into_cronjob_nested_template() {
+        let spec = json!({
+            "apiVersion": "batch/v1",
+            "kind": "CronJob",
+            "spec": { "jobTemplate": { "spec": { "template": { "spec": { "containers": [
+                { "name": "job", "image": "job:latest" }
+            ] } } } } }
+        });
+
+        let out = spec.with_injected_env(&vars());
+        let mut envs = Vec::new();
+        all_env_arrays(&out, &mut envs);
+
+        assert_eq!(envs.len(), 1);
+        assert_eq!(
+            env_value(&envs[0], "CICD_NON_LATEST_DEPLOY").as_deref(),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn injects_into_init_containers() {
+        let spec = json!({
+            "spec": { "template": { "spec": {
+                "initContainers": [ { "name": "migrate", "image": "app:latest" } ],
+                "containers": [ { "name": "app", "image": "app:latest" } ]
+            } } }
+        });
+
+        let out = spec.with_injected_env(&vars());
+        let mut envs = Vec::new();
+        all_env_arrays(&out, &mut envs);
+
+        // Both the init container and the app container get the vars.
+        assert_eq!(envs.len(), 2);
+        for env in &envs {
+            assert_eq!(
+                env_value(env, "CICD_ARTIFACT_SHA").as_deref(),
+                Some("abc123")
+            );
+        }
+    }
+
+    #[test]
+    fn upserts_preserving_other_vars_and_overwriting_collisions() {
+        let spec = json!({
+            "spec": { "template": { "spec": { "containers": [ {
+                "name": "app",
+                "image": "app:latest",
+                "env": [
+                    { "name": "EXISTING", "value": "keep" },
+                    { "name": "CICD_ARTIFACT_SHA", "value": "stale" }
+                ]
+            } ] } } }
+        });
+
+        let out = spec.with_injected_env(&vars());
+        let mut envs = Vec::new();
+        all_env_arrays(&out, &mut envs);
+
+        let env = &envs[0];
+        // Pre-existing unrelated var is preserved.
+        assert_eq!(env_value(env, "EXISTING").as_deref(), Some("keep"));
+        // Colliding var is overwritten, not duplicated.
+        assert_eq!(
+            env_value(env, "CICD_ARTIFACT_SHA").as_deref(),
+            Some("abc123")
+        );
+        let count = env
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|e| e.get("name").and_then(|n| n.as_str()) == Some("CICD_ARTIFACT_SHA"))
+            .count();
+        assert_eq!(count, 1);
+        // New var added.
+        assert_eq!(
+            env_value(env, "CICD_NON_LATEST_DEPLOY").as_deref(),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn valuefrom_collision_is_replaced_with_literal() {
+        let spec = json!({
+            "spec": { "template": { "spec": { "containers": [ {
+                "name": "app",
+                "env": [
+                    { "name": "CICD_ARTIFACT_SHA", "valueFrom": { "secretKeyRef": { "name": "s", "key": "k" } } }
+                ]
+            } ] } } }
+        });
+
+        let out = spec.with_injected_env(&vars());
+        let mut envs = Vec::new();
+        all_env_arrays(&out, &mut envs);
+
+        let entry = envs[0]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| e.get("name").and_then(|n| n.as_str()) == Some("CICD_ARTIFACT_SHA"))
+            .unwrap();
+        assert_eq!(entry.get("value").and_then(|v| v.as_str()), Some("abc123"));
+        assert!(entry.get("valueFrom").is_none());
     }
 }


### PR DESCRIPTION
## What

Injects a set of `CICD_*` environment variables into every container (and initContainer) of deployed workloads, so apps can report their version and make deploy-aware decisions.

The motivating use case: an app on a **branch or pinned-SHA deploy** can read `CICD_NON_LATEST_DEPLOY=true` and **fail closed on dangerous actions** — e.g. refuse to run a SQLite/DDL schema migration rather than risk mutating a shared schema. Branch deploys that don't touch the schema still work fine.

## How

- New `WithInjectedEnv` trait in `spec_editing.rs`, mirroring the existing `WithVersion` / `WithInterpolatedVersion` pattern. It recursively walks the spec JSON and, at any `containers`/`initContainers` array, **upserts** each var into the container's `env` (dedupes by name; a literal value supersedes a pre-existing `valueFrom`).
- `DeployConfig::deploy_env_vars()` assembles the set from deployment state; `DeployConfig::is_non_latest_deploy()` is the signal: `artifact.branch != default_branch`, which is `true` for both non-default branches and pinned-SHA overrides (`None != Some`).
- Wired into the reconcile loop in `controller.rs`, one line after the existing `with_version` interpolation.

## Injected variables

| Var | When | Notes |
|---|---|---|
| `CICD_NON_LATEST_DEPLOY` | always | `"true"`/`"false"`, always explicit |
| `CICD_DEPLOY_CONFIG`, `CICD_TEAM` | always | identity |
| `CICD_DEFAULT_BRANCH` | artifact repo configured | tracking branch |
| `CICD_ARTIFACT_SHA` (== `$SHA`), `CICD_ARTIFACT_BRANCH` | artifact deployed | |
| `CICD_CONFIG_SHA`, `CICD_CONFIG_BRANCH` | config deployed | |

Config-only deploys get the config vars and `CICD_NON_LATEST_DEPLOY=false` (no config default-branch tracking yet — a comment marks where to enable it when that API surface lands).

## Notes / caveats

- Pinned-SHA (`DeployCommit`) counts as non-latest even if the SHA matches the branch tip — a deliberate pin is a non-tracking deploy and should refuse migrations.
- The app-side guard is **fail-open** if a pre-this-change controller is ever running (the var would be absent). Once this ships it's a non-issue.

## Testing

- 5 new unit tests in `spec_editing.rs`: Deployment, nested CronJob template, initContainers, upsert preserving/overwriting collisions, and `valueFrom` replacement. All pass.
- `cargo clippy --all-targets` and `cargo fmt` clean (the 2 remaining clippy warnings are pre-existing in `deploy_history.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)