### PR TITLE
Authenticate to GitHub as a GitHub App instead of PATs

### DIFF
--- a/.deploy/cicd/deployment.yaml
+++ b/.deploy/cicd/deployment.yaml
@@ -28,10 +28,15 @@ spec:
               value: 'template-namespace'
             - name: DATABASE_PATH
               value: /data/db.db
-            - name: GITHUB_PATS
+            - name: GITHUB_APP_ID
               valueFrom:
                 secretKeyRef:
-                  key: GITHUB_PATS
+                  key: GITHUB_APP_ID
+                  name: cicd-auth
+            - name: GITHUB_APP_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: GITHUB_APP_PRIVATE_KEY
                   name: cicd-auth
             - name: CLIENT_SECRET
               valueFrom:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,7 @@ dependencies = [
  "futures-util",
  "indoc",
  "itertools",
+ "jsonwebtoken",
  "k8s-openapi",
  "kube",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ opentelemetry_sdk = { version = "0.21", features = [
 opentelemetry-prometheus = { version = "0.14" }
 prometheus = { version = "0.13" }
 octocrab = "0.46.0"
+jsonwebtoken = "9.3" # for octocrab App auth (EncodingKey)
 serde_yaml = "0.9.34"
 itertools = "0.14.0"
 sha2 = "0.10.9"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -460,6 +460,7 @@ Tests go in `tests/` directory (not yet implemented).
 4. Set environment variables:
    - `WEBSOCKET_URL` - GitHub webhook proxy
    - `CLIENT_SECRET` - Webhook authentication
+   - `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY` - GitHub App credentials (see README)
    - `DATABASE_PATH` - SQLite database path (optional, defaults to "db.db")
    - `TEMPLATE_NAMESPACE` - Template namespace for resource copying (optional)
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,36 @@ The application requires the following environment variables:
 
 - `WEBSOCKET_URL`: URL for the websocket proxy that forwards GitHub webhooks
 - `CLIENT_SECRET`: Secret for authenticating with the websocket proxy
+- `GITHUB_APP_ID`: Numeric ID of the GitHub App cicd authenticates as (see below)
+- `GITHUB_APP_PRIVATE_KEY`: The App's RSA private key, PEM text
 - `DATABASE_PATH`: (Optional) Path to the SQLite database file (defaults to "db.db")
+
+If `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY` are both unset, the application runs
+without GitHub API access (webhook ingestion still works, but bootstrap, commit
+parent lookup, deploy config fetching and deployment reporting are disabled).
+
+#### GitHub App Configuration
+
+cicd talks to GitHub as a [GitHub App](https://docs.github.com/en/apps) rather
+than with personal access tokens. The App is installed on each user or
+organization whose repositories should be tracked; each installation gets its
+own short-lived token, minted on demand. Installing with **All repositories**
+means new repos are covered the moment they are created, with no per-repo
+webhook to set up.
+
+The App needs:
+
+| Setting | Value |
+|---------|-------|
+| Webhook URL | The `/github` endpoint of the webhooks proxy |
+| Webhook secret | Must match the proxy's `WEBHOOK_SECRET` |
+| Repository permissions | Metadata: read, Contents: read, Checks: read, Deployments: read & write |
+| Subscribed events | Push, Check run, Delete, Repository |
+
+The `Repository` event is what tells cicd about repositories as soon as they
+are created. Installations are discovered at startup and re-listed at the start
+of every owner-wide bootstrap scan; installing the App on a new account is
+also picked up lazily on first use.
 
 #### Discord Notification Configuration
 
@@ -114,6 +143,8 @@ docker build -t cicd-dashboard .
 docker run -p 8080:8080 \
   -e WEBSOCKET_URL=your_websocket_url \
   -e CLIENT_SECRET=your_client_secret \
+  -e GITHUB_APP_ID=your_app_id \
+  -e GITHUB_APP_PRIVATE_KEY="$(cat your-app.private-key.pem)" \
   -v /path/to/data:/app/data \
   cicd-dashboard
 ```

--- a/src/crab_ext.rs
+++ b/src/crab_ext.rs
@@ -1,48 +1,385 @@
+//! GitHub API clients, authenticated as a GitHub App.
+//!
+//! The App itself (JWT auth) can only talk to `/app/*` routes. Everything
+//! repo-shaped goes through an *installation* of the App on a user or org
+//! account, so each installation gets its own [`Octocrab`] that mints and
+//! refreshes short-lived installation tokens on demand.
+//!
+//! Installations are listed from `GET /app/installations` at startup and
+//! again at the start of every owner-wide scan. A lookup for an account we
+//! have not seen yet falls through to `GET /repos/{owner}/{repo}/installation`,
+//! so installing the App somewhere new takes effect without a restart.
+
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::sync::{Arc, RwLock};
+
+use jsonwebtoken::EncodingKey;
+use octocrab::models::{AppId, Installation, InstallationId, InstallationRepositories};
 use octocrab::Octocrab;
+use serde::Serialize;
+
+use crate::error::{AppError, AppResult};
+
+const PER_PAGE: u8 = 100;
 
 pub trait IRepo {
     fn owner(&self) -> &str;
     fn repo(&self) -> &str;
 }
 
-pub type Octocrabs = Vec<Octocrab>;
-
-pub trait OctocrabExt {
-    async fn crab_for<T: IRepo>(&self, repo: &T) -> Option<&Octocrab>;
+/// A bare `owner/repo` pair, for call sites that only have the two strings.
+pub struct RepoRef<'a> {
+    pub owner: &'a str,
+    pub repo: &'a str,
 }
 
-impl OctocrabExt for Octocrabs {
-    async fn crab_for<T: IRepo>(&self, repo: &T) -> Option<&Octocrab> {
-        if self.len() == 1 {
-            return Some(&self[0]);
-        }
-
-        for crab in self {
-            let result = crab.repos(repo.owner(), repo.repo()).get().await;
-
-            if result.is_ok() {
-                return Some(crab);
-            }
-        }
-
-        None
+impl IRepo for RepoRef<'_> {
+    fn owner(&self) -> &str {
+        self.owner
+    }
+    fn repo(&self) -> &str {
+        self.repo
     }
 }
 
-pub fn initialize_octocrabs() -> Octocrabs {
-    let github_pats = std::env::var("GITHUB_PATS").ok();
-    let Some(github_pats) = github_pats else {
-        return vec![];
+/// GitHub logins are case-insensitive, so the registry is keyed on a folded form.
+fn account_key(login: &str) -> String {
+    login.to_ascii_lowercase()
+}
+
+/// Credentials for authenticating as the GitHub App, read from the environment.
+struct GitHubAppConfig {
+    app_id: AppId,
+    private_key: EncodingKey,
+}
+
+impl GitHubAppConfig {
+    /// Returns `Ok(None)` when neither variable is set, so local development
+    /// can run without GitHub credentials.
+    fn from_env() -> AppResult<Option<Self>> {
+        let app_id = std::env::var("GITHUB_APP_ID").ok();
+        let private_key = std::env::var("GITHUB_APP_PRIVATE_KEY").ok();
+
+        let (app_id, private_key) = match (app_id, private_key) {
+            (None, None) => return Ok(None),
+            (Some(app_id), Some(private_key)) => (app_id, private_key),
+            _ => {
+                return Err(AppError::Config(
+                    "GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY must be set together".to_string(),
+                ))
+            }
+        };
+
+        let app_id = app_id
+            .trim()
+            .parse::<u64>()
+            .map_err(|e| AppError::Config(format!("GITHUB_APP_ID is not a number: {}", e)))?;
+        let private_key = EncodingKey::from_rsa_pem(private_key.as_bytes()).map_err(|e| {
+            AppError::Config(format!(
+                "GITHUB_APP_PRIVATE_KEY is not a valid RSA PEM: {}",
+                e
+            ))
+        })?;
+
+        Ok(Some(Self {
+            app_id: AppId(app_id),
+            private_key,
+        }))
+    }
+}
+
+/// A GitHub client authorized as one installation of the App.
+///
+/// Derefs to [`Octocrab`], so call sites read the same as any other client
+/// (`crab.repos(..)`, `crab.ratelimit()`). Cloning shares the underlying
+/// client and its cached installation token.
+#[derive(Clone)]
+pub struct InstallationClient {
+    pub id: InstallationId,
+    /// Login of the user or organization the App is installed on.
+    pub account: String,
+    crab: Arc<Octocrab>,
+}
+
+impl Deref for InstallationClient {
+    type Target = Octocrab;
+
+    fn deref(&self) -> &Octocrab {
+        &self.crab
+    }
+}
+
+#[derive(Serialize)]
+struct PageParams {
+    per_page: u8,
+    page: u32,
+}
+
+impl InstallationClient {
+    /// Every repository this installation can see, across all pages.
+    pub async fn list_repos(&self) -> AppResult<Vec<octocrab::models::Repository>> {
+        let mut all = Vec::new();
+        let mut page: u32 = 1;
+        loop {
+            let params = PageParams {
+                per_page: PER_PAGE,
+                page,
+            };
+            let resp: InstallationRepositories = self
+                .crab
+                .get("/installation/repositories", Some(&params))
+                .await?;
+            let count = resp.repositories.len();
+            all.extend(resp.repositories);
+            if count < PER_PAGE as usize {
+                break;
+            }
+            page += 1;
+        }
+        Ok(all)
+    }
+}
+
+/// Registry of installation clients, keyed by the account each is installed on.
+///
+/// Cheap to clone: every clone shares the same clients and token caches.
+#[derive(Clone)]
+pub struct Octocrabs {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    /// Authenticated as the App itself. `None` when no App is configured.
+    app: Option<Octocrab>,
+    /// Keyed by [`account_key`] of the installation's account login.
+    installations: RwLock<HashMap<String, InstallationClient>>,
+}
+
+impl Octocrabs {
+    /// A registry with no credentials; every lookup misses.
+    pub fn disabled() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                app: None,
+                installations: RwLock::new(HashMap::new()),
+            }),
+        }
+    }
+
+    fn for_app(config: GitHubAppConfig) -> AppResult<Self> {
+        let app = Octocrab::builder()
+            .app(config.app_id, config.private_key)
+            .build()?;
+
+        Ok(Self {
+            inner: Arc::new(Inner {
+                app: Some(app),
+                installations: RwLock::new(HashMap::new()),
+            }),
+        })
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.inner.app.is_some()
+    }
+
+    /// Snapshot of the known installations, ordered by account for stable output.
+    pub fn installations(&self) -> Vec<InstallationClient> {
+        let mut clients: Vec<InstallationClient> = match self.inner.installations.read() {
+            Ok(map) => map.values().cloned().collect(),
+            Err(e) => {
+                log::error!("Installation registry lock poisoned: {}", e);
+                Vec::new()
+            }
+        };
+        clients.sort_by(|a, b| a.account.cmp(&b.account));
+        clients
+    }
+
+    /// Re-list installations from GitHub.
+    ///
+    /// Existing clients are kept so their cached tokens stay valid; new
+    /// installations are added and uninstalled ones are dropped.
+    pub async fn refresh_installations(&self) -> AppResult<()> {
+        let Some(app) = &self.inner.app else {
+            return Ok(());
+        };
+
+        let mut found: Vec<Installation> = Vec::new();
+        let mut page: u32 = 1;
+        loop {
+            let resp = app
+                .apps()
+                .installations()
+                .per_page(PER_PAGE)
+                .page(page)
+                .send()
+                .await?;
+            let count = resp.items.len();
+            found.extend(resp.items);
+            if count < PER_PAGE as usize {
+                break;
+            }
+            page += 1;
+        }
+
+        let mut next = HashMap::with_capacity(found.len());
+        for installation in found {
+            let key = account_key(&installation.account.login);
+            let existing = self.get(&key).filter(|client| client.id == installation.id);
+            let client = match existing {
+                Some(client) => client,
+                None => self.client_for(installation)?,
+            };
+            next.insert(key, client);
+        }
+
+        let mut map = self.inner.installations.write().map_err(|e| {
+            AppError::Internal(format!("Installation registry lock poisoned: {}", e))
+        })?;
+        *map = next;
+
+        Ok(())
+    }
+
+    /// The installation that can see `repo`, if any.
+    ///
+    /// Resolved by owner: an installation on an account covers that account's
+    /// repositories. Unknown owners are looked up through the App and cached
+    /// on success.
+    pub async fn crab_for<T: IRepo>(&self, repo: &T) -> Option<InstallationClient> {
+        let key = account_key(repo.owner());
+        if let Some(client) = self.get(&key) {
+            return Some(client);
+        }
+
+        let app = self.inner.app.as_ref()?;
+        let installation = match app
+            .apps()
+            .get_repository_installation(repo.owner(), repo.repo())
+            .await
+        {
+            Ok(installation) => installation,
+            Err(e) => {
+                log::debug!(
+                    "No GitHub App installation can access {}/{}: {}",
+                    repo.owner(),
+                    repo.repo(),
+                    e
+                );
+                return None;
+            }
+        };
+
+        match self.client_for(installation) {
+            Ok(client) => {
+                self.insert(client.clone());
+                Some(client)
+            }
+            Err(e) => {
+                log::warn!(
+                    "Failed to build client for installation covering {}/{}: {}",
+                    repo.owner(),
+                    repo.repo(),
+                    e
+                );
+                None
+            }
+        }
+    }
+
+    fn client_for(&self, installation: Installation) -> AppResult<InstallationClient> {
+        let Some(app) = &self.inner.app else {
+            return Err(AppError::Config("GitHub App is not configured".to_string()));
+        };
+
+        let crab = app.installation(installation.id)?;
+        log::info!(
+            "GitHub App installation {} on {} ({} repositories)",
+            installation.id,
+            installation.account.login,
+            installation
+                .repository_selection
+                .as_deref()
+                .unwrap_or("unknown")
+        );
+
+        Ok(InstallationClient {
+            id: installation.id,
+            account: installation.account.login,
+            crab: Arc::new(crab),
+        })
+    }
+
+    fn get(&self, key: &str) -> Option<InstallationClient> {
+        match self.inner.installations.read() {
+            Ok(map) => map.get(key).cloned(),
+            Err(e) => {
+                log::error!("Installation registry lock poisoned: {}", e);
+                None
+            }
+        }
+    }
+
+    fn insert(&self, client: InstallationClient) {
+        match self.inner.installations.write() {
+            Ok(mut map) => {
+                map.insert(account_key(&client.account), client);
+            }
+            Err(e) => log::error!("Installation registry lock poisoned: {}", e),
+        }
+    }
+}
+
+/// Build the registry from `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY`.
+///
+/// Missing configuration is not an error: the registry is empty and every
+/// GitHub-backed feature degrades to a logged warning. Failing to list
+/// installations at startup is also survivable — lookups fall through to
+/// GitHub, and the next owner scan re-lists.
+pub async fn initialize_octocrabs() -> AppResult<Octocrabs> {
+    let Some(config) = GitHubAppConfig::from_env()? else {
+        log::warn!("GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY not set; GitHub API access is disabled");
+        return Ok(Octocrabs::disabled());
     };
 
-    github_pats
-        .split(',')
-        .map(|pat| {
-            #[allow(clippy::expect_used)]
-            Octocrab::builder()
-                .personal_token(pat)
-                .build()
-                .expect("Failed to build Octocrab client - invalid GitHub PAT")
-        })
-        .collect()
+    let octocrabs = Octocrabs::for_app(config)?;
+    match octocrabs.refresh_installations().await {
+        Ok(()) => log::info!(
+            "GitHub App ready with {} installation(s)",
+            octocrabs.installations().len()
+        ),
+        Err(e) => log::error!("Failed to list GitHub App installations: {}", e),
+    }
+
+    Ok(octocrabs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn account_key_folds_case() {
+        assert_eq!(account_key("KJ800x"), "kj800x");
+        assert_eq!(account_key("kj800x"), account_key("KJ800X"));
+    }
+
+    #[test]
+    fn disabled_registry_has_no_installations() {
+        let octocrabs = Octocrabs::disabled();
+        assert!(!octocrabs.is_enabled());
+        assert!(octocrabs.installations().is_empty());
+    }
+
+    #[tokio::test]
+    async fn disabled_registry_never_resolves_a_repo() {
+        let octocrabs = Octocrabs::disabled();
+        let repo = RepoRef {
+            owner: "kj800x",
+            repo: "cicd",
+        };
+        assert!(octocrabs.crab_for(&repo).await.is_none());
+    }
 }

--- a/src/db/git_repo.rs
+++ b/src/db/git_repo.rs
@@ -40,6 +40,35 @@ impl From<WebhookRepository> for GitRepo {
     }
 }
 
+/// From the REST API's repository model, as returned by `GET /repos/{owner}/{repo}`
+/// and the list endpoints. Fails only if GitHub omitted the owner, which it
+/// does not do for real repositories.
+impl TryFrom<octocrab::models::Repository> for GitRepo {
+    type Error = AppError;
+
+    fn try_from(repo: octocrab::models::Repository) -> AppResult<Self> {
+        let owner_name = repo
+            .owner
+            .as_ref()
+            .map(|owner| owner.login.clone())
+            .ok_or_else(|| {
+                AppError::Parse(format!("GitHub repository {} has no owner", repo.name))
+            })?;
+
+        Ok(Self {
+            id: repo.id.0,
+            owner_name,
+            name: repo.name,
+            default_branch: repo.default_branch.unwrap_or_else(|| "main".to_string()),
+            private: repo.private.unwrap_or(false),
+            language: repo
+                .language
+                .as_ref()
+                .and_then(|v| v.as_str().map(|s| s.to_string())),
+        })
+    }
+}
+
 impl GitRepo {
     pub fn from_row(row: &rusqlite::Row) -> AppResult<Self> {
         Ok(GitRepo {

--- a/src/github_deployments.rs
+++ b/src/github_deployments.rs
@@ -17,7 +17,7 @@
 
 use serde_json::json;
 
-use crate::crab_ext::{IRepo, OctocrabExt, Octocrabs};
+use crate::crab_ext::{IRepo, Octocrabs};
 use crate::error::{AppError, AppResult};
 use crate::kubernetes::deploy_handlers::DeployAction;
 use crate::kubernetes::DeployConfig;
@@ -84,7 +84,7 @@ async fn report_success(octocrabs: &Octocrabs, repo: &impl IRepo, sha: &str, env
         return;
     };
 
-    if let Err(e) = create_success(crab, repo, sha, environment).await {
+    if let Err(e) = create_success(&crab, repo, sha, environment).await {
         log::warn!(
             "GitHub deployment report failed for {}/{} env={}: {}",
             repo.owner(),
@@ -154,7 +154,7 @@ async fn report_inactive(octocrabs: &Octocrabs, repo: &impl IRepo, environment: 
         return;
     };
 
-    if let Err(e) = set_inactive(crab, repo, environment).await {
+    if let Err(e) = set_inactive(&crab, repo, environment).await {
         log::warn!(
             "GitHub deployment deactivate failed for {}/{} env={}: {}",
             repo.owner(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,15 +144,14 @@ async fn poll_github_rate_limits(octocrabs: Octocrabs) {
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
     loop {
         interval.tick().await;
-        for (idx, crab) in octocrabs.iter().enumerate() {
-            let label = (idx + 1).to_string();
-            if let Ok(rate_info) = crab.ratelimit().get().await {
+        for installation in octocrabs.installations() {
+            if let Ok(rate_info) = installation.ratelimit().get().await {
                 let m = metrics::get();
                 m.github_rate_limit_remaining
-                    .with_label_values(&[&label])
+                    .with_label_values(&[&installation.account])
                     .set(rate_info.resources.core.remaining as i64);
                 m.github_rate_limit_limit
-                    .with_label_values(&[&label])
+                    .with_label_values(&[&installation.account])
                     .set(rate_info.resources.core.limit as i64);
             }
         }
@@ -176,8 +175,6 @@ async fn start_kubernetes_controller(
 #[actix_web::main]
 #[allow(clippy::expect_used)]
 async fn main() -> std::io::Result<()> {
-    let octocrabs: Octocrabs = initialize_octocrabs();
-
     // Configure logger with custom filter to prioritize Discord logs
     env_logger::builder()
         .filter_level(log::LevelFilter::Info) // Set default level to Info for most modules
@@ -189,6 +186,10 @@ async fn main() -> std::io::Result<()> {
         .filter_module("cicd::web", log::LevelFilter::Info)
         .parse_default_env()
         .init();
+
+    let octocrabs: Octocrabs = initialize_octocrabs()
+        .await
+        .expect("Failed to initialize GitHub App client");
 
     let registry = prometheus::Registry::new();
     let exporter = opentelemetry_prometheus::exporter()

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -26,7 +26,7 @@ pub fn init(registry: &prometheus::Registry) -> Result<(), anyhow::Error> {
             "cicd_github_rate_limit_remaining",
             "GitHub API rate limit remaining requests",
         ),
-        &["token"],
+        &["installation"],
     )?;
     registry.register(Box::new(github_rate_limit_remaining.clone()))?;
 
@@ -35,7 +35,7 @@ pub fn init(registry: &prometheus::Registry) -> Result<(), anyhow::Error> {
             "cicd_github_rate_limit_limit",
             "GitHub API rate limit total requests allowed",
         ),
-        &["token"],
+        &["installation"],
     )?;
     registry.register(Box::new(github_rate_limit_limit.clone()))?;
 

--- a/src/web/bootstrap.rs
+++ b/src/web/bootstrap.rs
@@ -1,4 +1,4 @@
-use crate::crab_ext::Octocrabs;
+use crate::crab_ext::{IRepo, InstallationClient, Octocrabs, RepoRef};
 use crate::db::{
     git_branch::GitBranchEgg, git_commit::GitCommitEgg, git_commit_build::GitCommitBuild,
     git_repo::GitRepo,
@@ -81,28 +81,6 @@ async fn log_rate_limit(crab: &Octocrab, label: &str) -> Option<usize> {
             None
         }
     }
-}
-
-async fn list_all_repos(crab: &Octocrab) -> anyhow::Result<Vec<octocrab::models::Repository>> {
-    let mut all: Vec<octocrab::models::Repository> = Vec::new();
-    let mut page: u8 = 1;
-    loop {
-        let resp = crab
-            .current()
-            .list_repos_for_authenticated_user()
-            .affiliation("owner")
-            .per_page(PER_PAGE)
-            .page(page)
-            .send()
-            .await?;
-        let count = resp.items.len() as u8;
-        all.extend(resp.items);
-        if count < PER_PAGE {
-            break;
-        }
-        page += 1;
-    }
-    Ok(all)
 }
 
 async fn list_all_branches(
@@ -385,43 +363,40 @@ async fn run_owner_bootstrap_impl(
         }
     };
 
-    for (idx, crab) in octocrabs.iter().enumerate() {
-        let token_label = format!("token-{}", idx + 1);
-        let start_remaining = log_rate_limit(crab, &format!("start-{}", token_label)).await;
-        match list_all_repos(crab).await {
+    // Pick up installations added since startup (or missed by a failed
+    // startup listing) before sweeping.
+    if let Err(e) = octocrabs.refresh_installations().await {
+        log::warn!("Bootstrap: refresh installations failed: {}", e);
+        log_append(format!("Warning: refresh installations failed: {}", e));
+    }
+    let installations = octocrabs.installations();
+    if installations.is_empty() {
+        log_append("No GitHub App installations found; nothing to scan");
+        return;
+    }
+    log_append(format!("Found {} installation(s)", installations.len()));
+
+    for installation in installations {
+        let crab = &installation;
+        let install_label = &installation.account;
+        let start_remaining = log_rate_limit(crab, &format!("start-{}", install_label)).await;
+        match installation.list_repos().await {
             Ok(repos) => {
-                log_append(format!("Discovered {} repositories", repos.len()));
+                log_append(format!(
+                    "Discovered {} repositories for {}",
+                    repos.len(),
+                    install_label
+                ));
                 for r in repos {
-                    let default_branch = r
-                        .default_branch
-                        .clone()
-                        .unwrap_or_else(|| "main".to_string());
-                    let (owner_name, name) = if let Some(full) = r.full_name.clone() {
-                        let mut parts = full.splitn(2, '/');
-                        (
-                            parts.next().unwrap_or_default().to_string(),
-                            parts.next().unwrap_or_default().to_string(),
-                        )
-                    } else {
-                        (
-                            r.owner
-                                .as_ref()
-                                .map(|o| o.login.clone())
-                                .unwrap_or_default(),
-                            r.name.clone(),
-                        )
+                    let repo = match GitRepo::try_from(r) {
+                        Ok(repo) => repo,
+                        Err(e) => {
+                            log::warn!("Bootstrap: skipping repository: {}", e);
+                            log_append(format!("Skipping repository: {}", e));
+                            continue;
+                        }
                     };
-                    let repo = GitRepo {
-                        id: r.id.0,
-                        owner_name,
-                        name,
-                        default_branch: default_branch.clone(),
-                        private: r.private.unwrap_or(false),
-                        language: r
-                            .language
-                            .as_ref()
-                            .and_then(|v| v.as_str().map(|s| s.to_string())),
-                    };
+                    let default_branch = repo.default_branch.clone();
                     if let Err(e) = repo.upsert(&conn) {
                         log::warn!(
                             "Bootstrap: upsert repo {}/{} failed: {}",
@@ -673,23 +648,89 @@ async fn run_owner_bootstrap_impl(
                         ));
                     }
                 }
-                let end_remaining = log_rate_limit(crab, &format!("end-{}", token_label)).await;
+                let end_remaining = log_rate_limit(crab, &format!("end-{}", install_label)).await;
 
                 // Calculate usage if we have both start and end measurements
                 if let (Some(start), Some(end)) = (start_remaining, end_remaining) {
                     let used = start.saturating_sub(end);
                     log_append(format!(
                         "Bootstrap used approximately {} API requests for {}",
-                        used, token_label
+                        used, install_label
                     ));
                 }
 
-                log_append("Bootstrap completed");
+                log_append(format!("Bootstrap completed for {}", install_label));
             }
             Err(e) => {
-                log::warn!("Bootstrap: list repos failed: {:?}", e);
-                log_append(format!("Error: list repos failed: {:?}", e));
+                log::warn!(
+                    "Bootstrap: list repos for {} failed: {:?}",
+                    install_label,
+                    e
+                );
+                log_append(format!(
+                    "Error: list repos for {} failed: {:?}",
+                    install_label, e
+                ));
             }
+        }
+    }
+}
+
+/// Resolve the installation covering `owner/repo`, logging to the bootstrap
+/// log when there is none.
+async fn installation_for(
+    octocrabs: &Octocrabs,
+    owner: &str,
+    repo: &str,
+) -> Option<InstallationClient> {
+    let installation = octocrabs.crab_for(&RepoRef { owner, repo }).await;
+    if installation.is_none() {
+        log::warn!(
+            "Bootstrap: no GitHub App installation can access {}/{}",
+            owner,
+            repo
+        );
+        log_append(format!(
+            "Error: no GitHub App installation can access {}/{}",
+            owner, repo
+        ));
+    }
+    installation
+}
+
+/// Fetch `owner/repo` from GitHub, logging to the bootstrap log on failure.
+async fn fetch_repo(crab: &Octocrab, owner: &str, repo_name: &str) -> Option<GitRepo> {
+    let repo_data = match crab.repos(owner, repo_name).get().await {
+        Ok(r) => r,
+        Err(e) => {
+            log::warn!(
+                "Bootstrap: fetch repo {}/{} failed: {:?}",
+                owner,
+                repo_name,
+                e
+            );
+            log_append(format!(
+                "Error: fetch repo {}/{} failed: {:?}",
+                owner, repo_name, e
+            ));
+            return None;
+        }
+    };
+
+    match GitRepo::try_from(repo_data) {
+        Ok(repo) => Some(repo),
+        Err(e) => {
+            log::warn!(
+                "Bootstrap: convert repo {}/{} failed: {}",
+                owner,
+                repo_name,
+                e
+            );
+            log_append(format!(
+                "Error: convert repo {}/{} failed: {}",
+                owner, repo_name, e
+            ));
+            None
         }
     }
 }
@@ -712,312 +753,282 @@ async fn run_repo_bootstrap_impl(
 
     log_append(format!("Scanning repo {}/{}", owner, repo_name));
 
-    for (idx, crab) in octocrabs.iter().enumerate() {
-        let token_label = format!("token-{}", idx + 1);
-        let start_remaining = log_rate_limit(crab, &format!("start-{}", token_label)).await;
+    let Some(installation) = installation_for(&octocrabs, &owner, &repo_name).await else {
+        return;
+    };
+    let crab = &installation;
+    let install_label = &installation.account;
+    let start_remaining = log_rate_limit(crab, &format!("start-{}", install_label)).await;
 
-        // Fetch the specific repository
-        let repo_data = match crab.repos(&owner, &repo_name).get().await {
-            Ok(r) => r,
-            Err(e) => {
-                log::warn!(
-                    "Bootstrap: fetch repo {}/{} failed: {:?}",
-                    owner,
-                    repo_name,
-                    e
-                );
-                log_append(format!(
-                    "Error: fetch repo {}/{} failed: {:?}",
-                    owner, repo_name, e
-                ));
-                continue;
-            }
-        };
+    let Some(repo) = fetch_repo(crab, &owner, &repo_name).await else {
+        return;
+    };
 
-        let default_branch = repo_data
-            .default_branch
-            .clone()
-            .unwrap_or_else(|| "main".to_string());
+    if let Err(e) = repo.upsert(&conn) {
+        log::warn!(
+            "Bootstrap: upsert repo {}/{} failed: {}",
+            owner,
+            repo_name,
+            e
+        );
+        log_append(format!(
+            "repo {}/{}: upsert failed: {}",
+            owner, repo_name, e
+        ));
+        return;
+    }
 
-        let repo = GitRepo {
-            id: repo_data.id.0,
-            owner_name: owner.clone(),
-            name: repo_name.clone(),
-            default_branch: default_branch.clone(),
-            private: repo_data.private.unwrap_or(false),
-            language: repo_data
-                .language
-                .as_ref()
-                .and_then(|v| v.as_str().map(|s| s.to_string())),
-        };
+    log_append(format!(
+        "repo {}/{}: fetching all branches",
+        owner, repo_name
+    ));
 
-        if let Err(e) = repo.upsert(&conn) {
+    // Fetch all branches for this repo
+    let branches = match list_all_branches(crab, &owner, &repo_name).await {
+        Ok(b) => b,
+        Err(e) => {
             log::warn!(
-                "Bootstrap: upsert repo {}/{} failed: {}",
+                "Bootstrap: list branches for {}/{} failed: {:?}",
                 owner,
                 repo_name,
                 e
             );
             log_append(format!(
-                "repo {}/{}: upsert failed: {}",
+                "repo {}/{}: list branches failed: {:?}",
                 owner, repo_name, e
             ));
             return;
         }
+    };
 
-        log_append(format!(
-            "repo {}/{}: fetching all branches",
-            owner, repo_name
-        ));
+    log_append(format!(
+        "repo {}/{}: processing {} branches",
+        owner,
+        repo_name,
+        branches.len()
+    ));
 
-        // Fetch all branches for this repo
-        let branches = match list_all_branches(crab, &owner, &repo_name).await {
-            Ok(b) => b,
+    for branch_data in branches {
+        let branch_name = branch_data.name.clone();
+
+        log_rate_limit(
+            crab,
+            &format!("before-commits-{}/{}@{}", owner, repo_name, branch_name),
+        )
+        .await;
+
+        let commits = match list_commits_for_branch(
+            crab,
+            &owner,
+            &repo_name,
+            &branch_name,
+            50, // Deep scan: 50 commits per branch
+        )
+        .await
+        {
+            Ok(c) => c,
             Err(e) => {
                 log::warn!(
-                    "Bootstrap: list branches for {}/{} failed: {:?}",
+                    "Bootstrap: list commits for {}/{}@{} failed: {:?}",
                     owner,
                     repo_name,
+                    branch_name,
                     e
                 );
                 log_append(format!(
-                    "repo {}/{}: list branches failed: {:?}",
-                    owner, repo_name, e
+                    "repo {}/{}: list commits for {} failed: {:?}",
+                    owner, repo_name, branch_name, e
                 ));
-                return;
+                continue;
             }
         };
 
         log_append(format!(
-            "repo {}/{}: processing {} branches",
+            "repo {}/{}: {} commits on {}",
             owner,
             repo_name,
-            branches.len()
+            commits.len(),
+            branch_name
         ));
 
-        for branch_data in branches {
-            let branch_name = branch_data.name.clone();
-
-            log_rate_limit(
-                crab,
-                &format!("before-commits-{}/{}@{}", owner, repo_name, branch_name),
-            )
-            .await;
-
-            let commits = match list_commits_for_branch(
-                crab,
-                &owner,
-                &repo_name,
-                &branch_name,
-                50, // Deep scan: 50 commits per branch
-            )
-            .await
-            {
-                Ok(c) => c,
+        if let Some(first) = commits.first() {
+            let branch_egg = GitBranchEgg {
+                name: branch_name.clone(),
+                head_commit_sha: first.sha.clone(),
+                repo_id: repo.id,
+                active: true,
+            };
+            let branch = match branch_egg.upsert(&conn) {
+                Ok(br) => br,
                 Err(e) => {
                     log::warn!(
-                        "Bootstrap: list commits for {}/{}@{} failed: {:?}",
+                        "Bootstrap: upsert branch {} for {}/{} failed: {}",
+                        branch_name,
                         owner,
                         repo_name,
-                        branch_name,
                         e
                     );
                     log_append(format!(
-                        "repo {}/{}: list commits for {} failed: {:?}",
+                        "repo {}/{}: upsert branch {} failed: {}",
                         owner, repo_name, branch_name, e
                     ));
                     continue;
                 }
             };
 
-            log_append(format!(
-                "repo {}/{}: {} commits on {}",
-                owner,
-                repo_name,
-                commits.len(),
-                branch_name
-            ));
+            for c in commits {
+                let author_name = c
+                    .commit
+                    .author
+                    .as_ref()
+                    .map(|a| a.name.clone())
+                    .unwrap_or_else(|| "unknown".to_string());
+                let committer_name = c
+                    .commit
+                    .committer
+                    .as_ref()
+                    .map(|a| a.name.clone())
+                    .unwrap_or_else(|| "unknown".to_string());
+                let ts_millis = c
+                    .commit
+                    .author
+                    .as_ref()
+                    .and_then(|a| a.date.as_ref())
+                    .or_else(|| c.commit.committer.as_ref().and_then(|a| a.date.as_ref()))
+                    .map(|d| d.timestamp_millis())
+                    .unwrap_or_else(|| Utc::now().timestamp_millis());
 
-            if let Some(first) = commits.first() {
-                let branch_egg = GitBranchEgg {
-                    name: branch_name.clone(),
-                    head_commit_sha: first.sha.clone(),
+                let egg = GitCommitEgg {
+                    sha: c.sha.clone(),
                     repo_id: repo.id,
-                    active: true,
+                    message: c.commit.message.clone(),
+                    author: author_name,
+                    committer: committer_name,
+                    timestamp: ts_millis,
                 };
-                let branch = match branch_egg.upsert(&conn) {
-                    Ok(br) => br,
+                let commit = match crate::db::git_commit::GitCommit::upsert(&egg, &conn) {
+                    Ok(cc) => cc,
                     Err(e) => {
                         log::warn!(
-                            "Bootstrap: upsert branch {} for {}/{} failed: {}",
-                            branch_name,
+                            "Bootstrap: upsert commit {} for {}/{} failed: {}",
+                            c.sha,
                             owner,
                             repo_name,
                             e
                         );
                         log_append(format!(
-                            "repo {}/{}: upsert branch {} failed: {}",
-                            owner, repo_name, branch_name, e
+                            "repo {}/{}: upsert commit {} failed: {}",
+                            owner, repo_name, c.sha, e
                         ));
                         continue;
                     }
                 };
 
-                for c in commits {
-                    let author_name = c
-                        .commit
-                        .author
-                        .as_ref()
-                        .map(|a| a.name.clone())
-                        .unwrap_or_else(|| "unknown".to_string());
-                    let committer_name = c
-                        .commit
-                        .committer
-                        .as_ref()
-                        .map(|a| a.name.clone())
-                        .unwrap_or_else(|| "unknown".to_string());
-                    let ts_millis = c
-                        .commit
-                        .author
-                        .as_ref()
-                        .and_then(|a| a.date.as_ref())
-                        .or_else(|| c.commit.committer.as_ref().and_then(|a| a.date.as_ref()))
-                        .map(|d| d.timestamp_millis())
-                        .unwrap_or_else(|| Utc::now().timestamp_millis());
+                let parent_shas: Vec<String> =
+                    c.parents.clone().into_iter().flat_map(|p| p.sha).collect();
+                if let Err(e) = commit.add_parent_shas(parent_shas, &conn) {
+                    log::debug!("Bootstrap: add parents for {} failed: {}", commit.sha, e);
+                }
+                if let Err(e) = commit.add_branch(branch.id, &conn) {
+                    log::debug!(
+                        "Bootstrap: add branch relation for {} failed: {}",
+                        commit.sha,
+                        e
+                    );
+                }
 
-                    let egg = GitCommitEgg {
-                        sha: c.sha.clone(),
-                        repo_id: repo.id,
-                        message: c.commit.message.clone(),
-                        author: author_name,
-                        committer: committer_name,
-                        timestamp: ts_millis,
-                    };
-                    let commit = match crate::db::git_commit::GitCommit::upsert(&egg, &conn) {
-                        Ok(cc) => cc,
-                        Err(e) => {
-                            log::warn!(
-                                "Bootstrap: upsert commit {} for {}/{} failed: {}",
-                                c.sha,
-                                owner,
-                                repo_name,
-                                e
-                            );
-                            log_append(format!(
-                                "repo {}/{}: upsert commit {} failed: {}",
-                                owner, repo_name, c.sha, e
-                            ));
-                            continue;
-                        }
-                    };
-
-                    let parent_shas: Vec<String> =
-                        c.parents.clone().into_iter().flat_map(|p| p.sha).collect();
-                    if let Err(e) = commit.add_parent_shas(parent_shas, &conn) {
-                        log::debug!("Bootstrap: add parents for {} failed: {}", commit.sha, e);
-                    }
-                    if let Err(e) = commit.add_branch(branch.id, &conn) {
-                        log::debug!(
-                            "Bootstrap: add branch relation for {} failed: {}",
-                            commit.sha,
-                            e
-                        );
-                    }
-
-                    // Fetch check runs and reconcile stored builds with GitHub.
-                    match get_check_runs_for_sha(crab, &owner, &repo_name, &commit.sha).await {
-                        Ok(checks) => {
-                            let builds: Vec<GitCommitBuild> = checks
-                                .into_iter()
-                                .map(|c| GitCommitBuild {
-                                    repo_id: repo.id,
-                                    commit_id: commit.id,
-                                    check_name: c.check_name,
-                                    status: c.status,
-                                    url: c.url,
-                                    start_time: c.start_time,
-                                    settle_time: c.settle_time,
-                                    app_id: c.app_id,
-                                })
-                                .collect();
-                            if let Err(e) = GitCommitBuild::reconcile_for_commit(
-                                repo.id, commit.id, &builds, &conn,
-                            ) {
-                                log::debug!(
-                                    "Bootstrap: reconcile builds for {} failed: {}",
-                                    commit.sha,
-                                    e
-                                );
-                            }
-                        }
-                        Err(e) => {
+                // Fetch check runs and reconcile stored builds with GitHub.
+                match get_check_runs_for_sha(crab, &owner, &repo_name, &commit.sha).await {
+                    Ok(checks) => {
+                        let builds: Vec<GitCommitBuild> = checks
+                            .into_iter()
+                            .map(|c| GitCommitBuild {
+                                repo_id: repo.id,
+                                commit_id: commit.id,
+                                check_name: c.check_name,
+                                status: c.status,
+                                url: c.url,
+                                start_time: c.start_time,
+                                settle_time: c.settle_time,
+                                app_id: c.app_id,
+                            })
+                            .collect();
+                        if let Err(e) =
+                            GitCommitBuild::reconcile_for_commit(repo.id, commit.id, &builds, &conn)
+                        {
                             log::debug!(
-                                "Bootstrap: fetch check runs for {} failed: {:?}",
+                                "Bootstrap: reconcile builds for {} failed: {}",
                                 commit.sha,
                                 e
                             );
                         }
                     }
-                }
-
-                // Sync deploy configs only for the HEAD of the default branch
-                if branch_name == repo.default_branch {
-                    let head_commit = &branch_egg.head_commit_sha;
-                    match sync_deploy_configs_for_commit(
-                        &octocrabs,
-                        &client,
-                        &pool,
-                        &owner,
-                        &repo_name,
-                        repo.id as u64,
-                        head_commit,
-                    )
-                    .await
-                    {
-                        Ok(_) => {
-                            log_append(format!(
-                                "repo {}/{}: synced deploy configs for HEAD of default branch ({})",
-                                owner,
-                                repo_name,
-                                &head_commit[..7]
-                            ));
-                        }
-                        Err(e) => {
-                            log::debug!(
-                                "Bootstrap: sync deploy configs for {}/{} @ {} failed: {:?}",
-                                owner,
-                                repo_name,
-                                head_commit,
-                                e
-                            );
-                        }
+                    Err(e) => {
+                        log::debug!(
+                            "Bootstrap: fetch check runs for {} failed: {:?}",
+                            commit.sha,
+                            e
+                        );
                     }
                 }
-            } else {
-                log_append(format!(
-                    "repo {}/{}: no commits on {}",
-                    owner, repo_name, branch_name
-                ));
             }
-        }
 
-        let end_remaining = log_rate_limit(crab, &format!("end-{}", token_label)).await;
-
-        // Calculate usage if we have both start and end measurements
-        if let (Some(start), Some(end)) = (start_remaining, end_remaining) {
-            let used = start.saturating_sub(end);
+            // Sync deploy configs only for the HEAD of the default branch
+            if branch_name == repo.default_branch {
+                let head_commit = &branch_egg.head_commit_sha;
+                match sync_deploy_configs_for_commit(
+                    &octocrabs,
+                    &client,
+                    &pool,
+                    &owner,
+                    &repo_name,
+                    repo.id as u64,
+                    head_commit,
+                )
+                .await
+                {
+                    Ok(_) => {
+                        log_append(format!(
+                            "repo {}/{}: synced deploy configs for HEAD of default branch ({})",
+                            owner,
+                            repo_name,
+                            &head_commit[..7]
+                        ));
+                    }
+                    Err(e) => {
+                        log::debug!(
+                            "Bootstrap: sync deploy configs for {}/{} @ {} failed: {:?}",
+                            owner,
+                            repo_name,
+                            head_commit,
+                            e
+                        );
+                    }
+                }
+            }
+        } else {
             log_append(format!(
-                "Deep repo scan used approximately {} API requests for {}",
-                used, token_label
+                "repo {}/{}: no commits on {}",
+                owner, repo_name, branch_name
             ));
         }
-
-        log_append(format!(
-            "Deep repo scan completed for {}/{}",
-            owner, repo_name
-        ));
-        break; // Only use the first token that works
     }
+
+    let end_remaining = log_rate_limit(crab, &format!("end-{}", install_label)).await;
+
+    // Calculate usage if we have both start and end measurements
+    if let (Some(start), Some(end)) = (start_remaining, end_remaining) {
+        let used = start.saturating_sub(end);
+        log_append(format!(
+            "Deep repo scan used approximately {} API requests for {}",
+            used, install_label
+        ));
+    }
+
+    log_append(format!(
+        "Deep repo scan completed for {}/{}",
+        owner, repo_name
+    ));
 }
 
 async fn run_repo_resync_impl(
@@ -1038,287 +1049,258 @@ async fn run_repo_resync_impl(
 
     log_append(format!("Resyncing repo {}/{}", owner, repo_name));
 
-    for (idx, crab) in octocrabs.iter().enumerate() {
-        let token_label = format!("token-{}", idx + 1);
-        let start_remaining = log_rate_limit(crab, &format!("start-{}", token_label)).await;
+    let Some(installation) = installation_for(&octocrabs, &owner, &repo_name).await else {
+        return;
+    };
+    let crab = &installation;
+    let install_label = &installation.account;
+    let start_remaining = log_rate_limit(crab, &format!("start-{}", install_label)).await;
 
-        // Fetch the specific repository
-        let repo_data = match crab.repos(&owner, &repo_name).get().await {
-            Ok(r) => r,
-            Err(e) => {
-                log::warn!(
-                    "Bootstrap: fetch repo {}/{} failed: {:?}",
-                    owner,
-                    repo_name,
-                    e
-                );
-                log_append(format!(
-                    "Error: fetch repo {}/{} failed: {:?}",
-                    owner, repo_name, e
-                ));
-                continue;
-            }
-        };
+    let Some(repo) = fetch_repo(crab, &owner, &repo_name).await else {
+        return;
+    };
+    let default_branch = repo.default_branch.clone();
 
-        let default_branch = repo_data
-            .default_branch
-            .clone()
-            .unwrap_or_else(|| "main".to_string());
+    if let Err(e) = repo.upsert(&conn) {
+        log::warn!(
+            "Bootstrap: upsert repo {}/{} failed: {}",
+            owner,
+            repo_name,
+            e
+        );
+        log_append(format!(
+            "repo {}/{}: upsert failed: {}",
+            owner, repo_name, e
+        ));
+        return;
+    }
 
-        let repo = GitRepo {
-            id: repo_data.id.0,
-            owner_name: owner.clone(),
-            name: repo_name.clone(),
-            default_branch: default_branch.clone(),
-            private: repo_data.private.unwrap_or(false),
-            language: repo_data
-                .language
-                .as_ref()
-                .and_then(|v| v.as_str().map(|s| s.to_string())),
-        };
+    log_append(format!(
+        "repo {}/{}: fetching latest commit on {}",
+        owner, repo_name, default_branch
+    ));
 
-        if let Err(e) = repo.upsert(&conn) {
+    // Fetch only the latest commit on the default branch
+    let commits = match list_commits_for_branch(
+        crab,
+        &owner,
+        &repo_name,
+        &default_branch,
+        1, // Only fetch 1 commit
+    )
+    .await
+    {
+        Ok(c) => c,
+        Err(e) => {
             log::warn!(
-                "Bootstrap: upsert repo {}/{} failed: {}",
+                "Bootstrap: list commits for {}/{}@{} failed: {:?}",
                 owner,
                 repo_name,
+                default_branch,
                 e
             );
             log_append(format!(
-                "repo {}/{}: upsert failed: {}",
-                owner, repo_name, e
+                "repo {}/{}: list commits for {} failed: {:?}",
+                owner, repo_name, default_branch, e
             ));
             return;
         }
+    };
 
+    if let Some(head_commit_data) = commits.first() {
         log_append(format!(
-            "repo {}/{}: fetching latest commit on {}",
-            owner, repo_name, default_branch
+            "repo {}/{}: processing commit {}",
+            owner,
+            repo_name,
+            &head_commit_data.sha[..7]
         ));
 
-        // Fetch only the latest commit on the default branch
-        let commits = match list_commits_for_branch(
-            crab,
-            &owner,
-            &repo_name,
-            &default_branch,
-            1, // Only fetch 1 commit
-        )
-        .await
-        {
-            Ok(c) => c,
+        let branch_egg = GitBranchEgg {
+            name: default_branch.clone(),
+            head_commit_sha: head_commit_data.sha.clone(),
+            repo_id: repo.id,
+            active: true,
+        };
+        let branch = match branch_egg.upsert(&conn) {
+            Ok(br) => br,
             Err(e) => {
                 log::warn!(
-                    "Bootstrap: list commits for {}/{}@{} failed: {:?}",
+                    "Bootstrap: upsert branch {} for {}/{} failed: {}",
+                    default_branch,
                     owner,
                     repo_name,
-                    default_branch,
                     e
                 );
                 log_append(format!(
-                    "repo {}/{}: list commits for {} failed: {:?}",
+                    "repo {}/{}: upsert branch {} failed: {}",
                     owner, repo_name, default_branch, e
                 ));
                 return;
             }
         };
 
-        if let Some(head_commit_data) = commits.first() {
-            log_append(format!(
-                "repo {}/{}: processing commit {}",
-                owner,
-                repo_name,
-                &head_commit_data.sha[..7]
-            ));
+        let author_name = head_commit_data
+            .commit
+            .author
+            .as_ref()
+            .map(|a| a.name.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+        let committer_name = head_commit_data
+            .commit
+            .committer
+            .as_ref()
+            .map(|a| a.name.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+        let ts_millis = head_commit_data
+            .commit
+            .author
+            .as_ref()
+            .and_then(|a| a.date.as_ref())
+            .or_else(|| {
+                head_commit_data
+                    .commit
+                    .committer
+                    .as_ref()
+                    .and_then(|a| a.date.as_ref())
+            })
+            .map(|d| d.timestamp_millis())
+            .unwrap_or_else(|| Utc::now().timestamp_millis());
 
-            let branch_egg = GitBranchEgg {
-                name: default_branch.clone(),
-                head_commit_sha: head_commit_data.sha.clone(),
-                repo_id: repo.id,
-                active: true,
-            };
-            let branch = match branch_egg.upsert(&conn) {
-                Ok(br) => br,
-                Err(e) => {
-                    log::warn!(
-                        "Bootstrap: upsert branch {} for {}/{} failed: {}",
-                        default_branch,
-                        owner,
-                        repo_name,
-                        e
-                    );
-                    log_append(format!(
-                        "repo {}/{}: upsert branch {} failed: {}",
-                        owner, repo_name, default_branch, e
-                    ));
-                    return;
-                }
-            };
-
-            let author_name = head_commit_data
-                .commit
-                .author
-                .as_ref()
-                .map(|a| a.name.clone())
-                .unwrap_or_else(|| "unknown".to_string());
-            let committer_name = head_commit_data
-                .commit
-                .committer
-                .as_ref()
-                .map(|a| a.name.clone())
-                .unwrap_or_else(|| "unknown".to_string());
-            let ts_millis = head_commit_data
-                .commit
-                .author
-                .as_ref()
-                .and_then(|a| a.date.as_ref())
-                .or_else(|| {
-                    head_commit_data
-                        .commit
-                        .committer
-                        .as_ref()
-                        .and_then(|a| a.date.as_ref())
-                })
-                .map(|d| d.timestamp_millis())
-                .unwrap_or_else(|| Utc::now().timestamp_millis());
-
-            let egg = GitCommitEgg {
-                sha: head_commit_data.sha.clone(),
-                repo_id: repo.id,
-                message: head_commit_data.commit.message.clone(),
-                author: author_name,
-                committer: committer_name,
-                timestamp: ts_millis,
-            };
-            let commit = match crate::db::git_commit::GitCommit::upsert(&egg, &conn) {
-                Ok(cc) => cc,
-                Err(e) => {
-                    log::warn!(
-                        "Bootstrap: upsert commit {} for {}/{} failed: {}",
-                        head_commit_data.sha,
-                        owner,
-                        repo_name,
-                        e
-                    );
-                    log_append(format!(
-                        "repo {}/{}: upsert commit {} failed: {}",
-                        owner, repo_name, head_commit_data.sha, e
-                    ));
-                    return;
-                }
-            };
-
-            let parent_shas: Vec<String> = head_commit_data
-                .parents
-                .clone()
-                .into_iter()
-                .flat_map(|p| p.sha)
-                .collect();
-            if let Err(e) = commit.add_parent_shas(parent_shas, &conn) {
-                log::debug!("Bootstrap: add parents for {} failed: {}", commit.sha, e);
+        let egg = GitCommitEgg {
+            sha: head_commit_data.sha.clone(),
+            repo_id: repo.id,
+            message: head_commit_data.commit.message.clone(),
+            author: author_name,
+            committer: committer_name,
+            timestamp: ts_millis,
+        };
+        let commit = match crate::db::git_commit::GitCommit::upsert(&egg, &conn) {
+            Ok(cc) => cc,
+            Err(e) => {
+                log::warn!(
+                    "Bootstrap: upsert commit {} for {}/{} failed: {}",
+                    head_commit_data.sha,
+                    owner,
+                    repo_name,
+                    e
+                );
+                log_append(format!(
+                    "repo {}/{}: upsert commit {} failed: {}",
+                    owner, repo_name, head_commit_data.sha, e
+                ));
+                return;
             }
-            if let Err(e) = commit.add_branch(branch.id, &conn) {
+        };
+
+        let parent_shas: Vec<String> = head_commit_data
+            .parents
+            .clone()
+            .into_iter()
+            .flat_map(|p| p.sha)
+            .collect();
+        if let Err(e) = commit.add_parent_shas(parent_shas, &conn) {
+            log::debug!("Bootstrap: add parents for {} failed: {}", commit.sha, e);
+        }
+        if let Err(e) = commit.add_branch(branch.id, &conn) {
+            log::debug!(
+                "Bootstrap: add branch relation for {} failed: {}",
+                commit.sha,
+                e
+            );
+        }
+
+        // Fetch check runs and reconcile stored builds with GitHub.
+        match get_check_runs_for_sha(crab, &owner, &repo_name, &commit.sha).await {
+            Ok(checks) => {
+                let builds: Vec<GitCommitBuild> = checks
+                    .into_iter()
+                    .map(|c| GitCommitBuild {
+                        repo_id: repo.id,
+                        commit_id: commit.id,
+                        check_name: c.check_name,
+                        status: c.status,
+                        url: c.url,
+                        start_time: c.start_time,
+                        settle_time: c.settle_time,
+                        app_id: c.app_id,
+                    })
+                    .collect();
+                if let Err(e) =
+                    GitCommitBuild::reconcile_for_commit(repo.id, commit.id, &builds, &conn)
+                {
+                    log::debug!(
+                        "Bootstrap: reconcile builds for {} failed: {}",
+                        commit.sha,
+                        e
+                    );
+                    log_append(format!(
+                        "repo {}/{}: reconcile builds for {} failed: {}",
+                        owner, repo_name, commit.sha, e
+                    ));
+                }
+            }
+            Err(e) => {
                 log::debug!(
-                    "Bootstrap: add branch relation for {} failed: {}",
+                    "Bootstrap: fetch check runs for {} failed: {:?}",
                     commit.sha,
                     e
                 );
             }
-
-            // Fetch check runs and reconcile stored builds with GitHub.
-            match get_check_runs_for_sha(crab, &owner, &repo_name, &commit.sha).await {
-                Ok(checks) => {
-                    let builds: Vec<GitCommitBuild> = checks
-                        .into_iter()
-                        .map(|c| GitCommitBuild {
-                            repo_id: repo.id,
-                            commit_id: commit.id,
-                            check_name: c.check_name,
-                            status: c.status,
-                            url: c.url,
-                            start_time: c.start_time,
-                            settle_time: c.settle_time,
-                            app_id: c.app_id,
-                        })
-                        .collect();
-                    if let Err(e) =
-                        GitCommitBuild::reconcile_for_commit(repo.id, commit.id, &builds, &conn)
-                    {
-                        log::debug!(
-                            "Bootstrap: reconcile builds for {} failed: {}",
-                            commit.sha,
-                            e
-                        );
-                        log_append(format!(
-                            "repo {}/{}: reconcile builds for {} failed: {}",
-                            owner, repo_name, commit.sha, e
-                        ));
-                    }
-                }
-                Err(e) => {
-                    log::debug!(
-                        "Bootstrap: fetch check runs for {} failed: {:?}",
-                        commit.sha,
-                        e
-                    );
-                }
-            }
-
-            // Sync deploy configs for HEAD of default branch
-            match sync_deploy_configs_for_commit(
-                &octocrabs,
-                &client,
-                &pool,
-                &owner,
-                &repo_name,
-                repo.id as u64,
-                &commit.sha,
-            )
-            .await
-            {
-                Ok(_) => {
-                    log_append(format!(
-                        "repo {}/{}: synced deploy configs for HEAD of default branch ({})",
-                        owner,
-                        repo_name,
-                        &commit.sha[..7]
-                    ));
-                }
-                Err(e) => {
-                    log::debug!(
-                        "Bootstrap: sync deploy configs for {}/{} @ {} failed: {:?}",
-                        owner,
-                        repo_name,
-                        commit.sha,
-                        e
-                    );
-                    log_append(format!(
-                        "repo {}/{}: sync deploy configs failed: {:?}",
-                        owner, repo_name, e
-                    ));
-                }
-            }
-        } else {
-            log_append(format!(
-                "repo {}/{}: no commits on {}",
-                owner, repo_name, default_branch
-            ));
         }
 
-        let end_remaining = log_rate_limit(crab, &format!("end-{}", token_label)).await;
-
-        // Calculate usage if we have both start and end measurements
-        if let (Some(start), Some(end)) = (start_remaining, end_remaining) {
-            let used = start.saturating_sub(end);
-            log_append(format!(
-                "Repo resync used approximately {} API requests for {}",
-                used, token_label
-            ));
+        // Sync deploy configs for HEAD of default branch
+        match sync_deploy_configs_for_commit(
+            &octocrabs,
+            &client,
+            &pool,
+            &owner,
+            &repo_name,
+            repo.id as u64,
+            &commit.sha,
+        )
+        .await
+        {
+            Ok(_) => {
+                log_append(format!(
+                    "repo {}/{}: synced deploy configs for HEAD of default branch ({})",
+                    owner,
+                    repo_name,
+                    &commit.sha[..7]
+                ));
+            }
+            Err(e) => {
+                log::debug!(
+                    "Bootstrap: sync deploy configs for {}/{} @ {} failed: {:?}",
+                    owner,
+                    repo_name,
+                    commit.sha,
+                    e
+                );
+                log_append(format!(
+                    "repo {}/{}: sync deploy configs failed: {:?}",
+                    owner, repo_name, e
+                ));
+            }
         }
-
-        log_append(format!("Resync completed for {}/{}", owner, repo_name));
-        break; // Only use the first token that works
+    } else {
+        log_append(format!(
+            "repo {}/{}: no commits on {}",
+            owner, repo_name, default_branch
+        ));
     }
+
+    let end_remaining = log_rate_limit(crab, &format!("end-{}", install_label)).await;
+
+    // Calculate usage if we have both start and end measurements
+    if let (Some(start), Some(end)) = (start_remaining, end_remaining) {
+        let used = start.saturating_sub(end);
+        log_append(format!(
+            "Repo resync used approximately {} API requests for {}",
+            used, install_label
+        ));
+    }
+
+    log_append(format!("Resync completed for {}/{}", owner, repo_name));
 }
 
 async fn run_bootstrap(pool: Pool<SqliteConnectionManager>, octocrabs: Octocrabs, client: Client) {
@@ -1399,6 +1381,24 @@ pub struct RepoBootstrapRequest {
     repo: String,
 }
 
+impl IRepo for RepoBootstrapRequest {
+    fn owner(&self) -> &str {
+        &self.owner
+    }
+    fn repo(&self) -> &str {
+        &self.repo
+    }
+}
+
+/// Whether some installation can actually read the repo, not just whether
+/// one covers its owner.
+async fn repo_accessible(octocrabs: &Octocrabs, repo: &impl IRepo) -> bool {
+    match octocrabs.crab_for(repo).await {
+        Some(crab) => crab.repos(repo.owner(), repo.repo()).get().await.is_ok(),
+        None => false,
+    }
+}
+
 #[post("/bootstrap/repo")]
 pub async fn bootstrap_repo(
     pool: web::Data<Pool<SqliteConnectionManager>>,
@@ -1412,16 +1412,7 @@ pub async fn bootstrap_repo(
             .body("A bootstrap task is already running. Please wait for it to complete.");
     }
 
-    // Validate that the repo exists
-    let mut repo_found = false;
-    for crab in octocrabs.iter() {
-        if (crab.repos(&req.owner, &req.repo).get().await).is_ok() {
-            repo_found = true;
-            break;
-        }
-    }
-
-    if !repo_found {
+    if !repo_accessible(&octocrabs, &*req).await {
         release_lock();
         return HttpResponse::build(StatusCode::NOT_FOUND)
             .content_type("text/html; charset=utf-8")
@@ -1463,16 +1454,7 @@ pub async fn bootstrap_repo_resync(
             .body("A bootstrap task is already running. Please wait for it to complete.");
     }
 
-    // Validate that the repo exists
-    let mut repo_found = false;
-    for crab in octocrabs.iter() {
-        if (crab.repos(&req.owner, &req.repo).get().await).is_ok() {
-            repo_found = true;
-            break;
-        }
-    }
-
-    if !repo_found {
+    if !repo_accessible(&octocrabs, &*req).await {
         release_lock();
         return HttpResponse::build(StatusCode::NOT_FOUND)
             .content_type("text/html; charset=utf-8")
@@ -1523,9 +1505,9 @@ pub async fn bootstrap_log() -> impl Responder {
 pub async fn rate_limits(octocrabs: web::Data<Octocrabs>) -> impl Responder {
     let mut results = Vec::new();
 
-    for (idx, crab) in octocrabs.iter().enumerate() {
-        let token_num = idx + 1;
-        match crab.ratelimit().get().await {
+    for installation in octocrabs.installations() {
+        let account = installation.account.clone();
+        match installation.ratelimit().get().await {
             Ok(rate_info) => {
                 // Convert Unix timestamp to New York time
                 use chrono::{TimeZone, Utc};
@@ -1540,7 +1522,7 @@ pub async fn rate_limits(octocrabs: web::Data<Octocrabs>) -> impl Responder {
                     .unwrap_or_else(|| "Unknown".to_string());
 
                 results.push((
-                    token_num,
+                    account,
                     Some(rate_info.resources.core.remaining),
                     Some(rate_info.resources.core.limit),
                     Some(reset_dt),
@@ -1548,19 +1530,30 @@ pub async fn rate_limits(octocrabs: web::Data<Octocrabs>) -> impl Responder {
             }
             Err(e) => {
                 log::debug!(
-                    "Failed to fetch rate limit for token {}: {:?}",
-                    token_num,
+                    "Failed to fetch rate limit for installation {}: {:?}",
+                    account,
                     e
                 );
-                results.push((token_num, None, None, None));
+                results.push((account, None, None, None));
             }
         }
     }
 
     let markup = maud::html! {
-        @for (token_num, remaining, limit, reset) in results {
+        @if results.is_empty() {
             div class="rate-limit-row" {
-                div class="rate-limit-token" { "Token " (token_num) }
+                div class="rate-limit-error" {
+                    @if octocrabs.is_enabled() {
+                        "No GitHub App installations found"
+                    } @else {
+                        "GitHub App not configured"
+                    }
+                }
+            }
+        }
+        @for (account, remaining, limit, reset) in results {
+            div class="rate-limit-row" {
+                div class="rate-limit-token" { (account) }
                 @if let (Some(rem), Some(lim), Some(rst)) = (remaining, limit, reset) {
                     div class="rate-limit-usage" {
                         span class="rate-limit-numbers" { (rem) " / " (lim) }

--- a/src/webhooks/config_sync.rs
+++ b/src/webhooks/config_sync.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use serenity::async_trait;
 
 use crate::{
-    crab_ext::{IRepo, OctocrabExt, Octocrabs},
+    crab_ext::{IRepo, Octocrabs},
     db::{
         deploy_config::DeployConfig as DbDeployConfig, deploy_config_version::DeployConfigVersion,
         git_repo::GitRepo,

--- a/src/webhooks/database.rs
+++ b/src/webhooks/database.rs
@@ -7,7 +7,7 @@ use serenity::async_trait;
 
 use crate::{
     build_status::BuildStatus,
-    crab_ext::{OctocrabExt, Octocrabs},
+    crab_ext::{Octocrabs, RepoRef},
     db::{
         git_branch::{GitBranch, GitBranchEgg},
         git_commit::{GitCommit, GitCommitEgg},
@@ -15,7 +15,9 @@ use crate::{
         git_repo::GitRepo,
     },
     webhooks::{
-        models::{CheckRunEvent, DeleteEvent, PushEvent},
+        models::{
+            CheckRunEvent, DeleteEvent, InstallationRepositoriesEvent, PushEvent, RepositoryEvent,
+        },
         util::{extract_branch_name, rfc3339_to_millis},
         WebhookHandler,
     },
@@ -188,6 +190,97 @@ impl WebhookHandler for DatabaseHandler {
                 branch
                     .mark_inactive(&conn)
                     .context("Error marking branch inactive")?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_repository(&self, payload: RepositoryEvent) -> Result<(), anyhow::Error> {
+        log::debug!("Received repository event:\n{:#?}", payload);
+
+        match payload.action.as_str() {
+            // Each of these carries the full, current repository object, so
+            // upserting keeps our row in step with GitHub. `created` is the
+            // important one: it lets a brand-new repo show up before its
+            // first push.
+            "created" | "edited" | "renamed" | "transferred" | "publicized" | "privatized"
+            | "unarchived" => {
+                let conn = self
+                    .pool
+                    .get()
+                    .context("Failed to get database connection")?;
+
+                let repo: GitRepo = payload.repository.into();
+                repo.upsert(&conn).context("Error upserting repository")?;
+                log::info!(
+                    "Repository {}/{} {}",
+                    repo.owner_name,
+                    repo.name,
+                    payload.action
+                );
+            }
+            // Deleted and archived repos keep their rows: there is no repo
+            // removal path today, and their history stays useful.
+            _ => log::debug!(
+                "Ignoring repository {} for {}/{}",
+                payload.action,
+                payload.repository.owner.login,
+                payload.repository.name
+            ),
+        }
+
+        Ok(())
+    }
+
+    async fn handle_installation_repositories(
+        &self,
+        payload: InstallationRepositoriesEvent,
+    ) -> Result<(), anyhow::Error> {
+        log::debug!("Received installation_repositories event:\n{:#?}", payload);
+
+        // Removal keeps rows for the same reason repository.deleted does.
+        if payload.action != "added" {
+            return Ok(());
+        }
+
+        let conn = self
+            .pool
+            .get()
+            .context("Failed to get database connection")?;
+
+        for added in payload.repositories_added {
+            let Some((owner, name)) = added.full_name.split_once('/') else {
+                log::warn!("Malformed repository full_name: {}", added.full_name);
+                continue;
+            };
+
+            // The payload only carries id/name/private; fetch the rest so the
+            // row is complete. Best-effort per repo so one failure doesn't
+            // hide the others.
+            let Some(crab) = self
+                .octocrabs
+                .crab_for(&RepoRef { owner, repo: name })
+                .await
+            else {
+                log::warn!("No GitHub App installation can access {}", added.full_name);
+                continue;
+            };
+
+            let repo = match crab.repos(owner, name).get().await {
+                Ok(repo_data) => GitRepo::try_from(repo_data),
+                Err(e) => {
+                    log::warn!("Failed to fetch {}: {}", added.full_name, e);
+                    continue;
+                }
+            };
+
+            match repo {
+                Ok(repo) => {
+                    repo.upsert(&conn).context("Error upserting repository")?;
+                    log::info!("Repository {} added to installation", added.full_name);
+                }
+                Err(e) => log::warn!("Failed to convert {}: {}", added.full_name, e),
             }
         }
 

--- a/src/webhooks/log.rs
+++ b/src/webhooks/log.rs
@@ -2,7 +2,10 @@
 use serenity::async_trait;
 
 use crate::webhooks::{
-    models::{CheckRunEvent, CheckSuiteEvent, DeleteEvent, PushEvent},
+    models::{
+        CheckRunEvent, CheckSuiteEvent, DeleteEvent, InstallationRepositoriesEvent, PushEvent,
+        RepositoryEvent,
+    },
     WebhookHandler,
 };
 
@@ -33,6 +36,19 @@ impl WebhookHandler for LogHandler {
 
     async fn handle_delete(&self, event: DeleteEvent) -> Result<(), anyhow::Error> {
         log::info!("Received delete event:\n{:#?}", event);
+        Ok(())
+    }
+
+    async fn handle_repository(&self, event: RepositoryEvent) -> Result<(), anyhow::Error> {
+        log::info!("Received repository event:\n{:#?}", event);
+        Ok(())
+    }
+
+    async fn handle_installation_repositories(
+        &self,
+        event: InstallationRepositoriesEvent,
+    ) -> Result<(), anyhow::Error> {
+        log::info!("Received installation_repositories event:\n{:#?}", event);
         Ok(())
     }
 

--- a/src/webhooks/manager.rs
+++ b/src/webhooks/manager.rs
@@ -6,7 +6,9 @@ use crate::prelude::*;
 use crate::webhooks::models::CheckRunEvent;
 use crate::webhooks::models::CheckSuiteEvent;
 use crate::webhooks::models::DeleteEvent;
+use crate::webhooks::models::InstallationRepositoriesEvent;
 use crate::webhooks::models::PushEvent;
+use crate::webhooks::models::RepositoryEvent;
 use crate::webhooks::models::WebhookEvent;
 use crate::webhooks::WebhookHandler;
 use futures_util::SinkExt;
@@ -227,6 +229,43 @@ impl WebhookManager {
                     e
                 ))),
             },
+            "repository" => match serde_json::from_value::<RepositoryEvent>(event.payload) {
+                Ok(payload) => {
+                    for handler in &self.handlers {
+                        let handler_result = handler.handle_repository(payload.clone()).await;
+                        if let Err(e) = handler_result {
+                            log::error!("Error handling repository:\n{}", format_anyhow_chain(&e));
+                        }
+                    }
+                    Ok(())
+                }
+                Err(e) => Err(anyhow::Error::msg(format!(
+                    "Error parsing repository event: {}",
+                    e
+                ))),
+            },
+            "installation_repositories" => {
+                match serde_json::from_value::<InstallationRepositoriesEvent>(event.payload) {
+                    Ok(payload) => {
+                        for handler in &self.handlers {
+                            let handler_result = handler
+                                .handle_installation_repositories(payload.clone())
+                                .await;
+                            if let Err(e) = handler_result {
+                                log::error!(
+                                    "Error handling installation_repositories:\n{}",
+                                    format_anyhow_chain(&e)
+                                );
+                            }
+                        }
+                        Ok(())
+                    }
+                    Err(e) => Err(anyhow::Error::msg(format!(
+                        "Error parsing installation_repositories event: {}",
+                        e
+                    ))),
+                }
+            }
             _ => {
                 log::debug!("Received unknown event: {}", event.event_type);
                 for handler in &self.handlers {

--- a/src/webhooks/mod.rs
+++ b/src/webhooks/mod.rs
@@ -1,6 +1,9 @@
 use serenity::async_trait;
 
-use crate::webhooks::models::{CheckRunEvent, CheckSuiteEvent, DeleteEvent, PushEvent};
+use crate::webhooks::models::{
+    CheckRunEvent, CheckSuiteEvent, DeleteEvent, InstallationRepositoriesEvent, PushEvent,
+    RepositoryEvent,
+};
 
 pub mod config_sync;
 pub mod database;
@@ -22,6 +25,15 @@ pub trait WebhookHandler {
         Ok(())
     }
     async fn handle_delete(&self, __event: DeleteEvent) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+    async fn handle_repository(&self, __event: RepositoryEvent) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+    async fn handle_installation_repositories(
+        &self,
+        __event: InstallationRepositoriesEvent,
+    ) -> Result<(), anyhow::Error> {
         Ok(())
     }
     async fn handle_unknown(&self, __event_type: &str) -> Result<(), anyhow::Error> {

--- a/src/webhooks/models.rs
+++ b/src/webhooks/models.rs
@@ -116,3 +116,34 @@ pub struct CheckSuiteEvent {
     pub check_suite: CheckSuite,
     pub repository: Repository,
 }
+
+/// Sent to a GitHub App for repositories it is installed on. With an
+/// "all repositories" installation this includes `created`, which is the
+/// only way to learn about a brand-new repo before its first push.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RepositoryEvent {
+    /// created | deleted | archived | unarchived | edited | renamed |
+    /// transferred | publicized | privatized
+    pub action: String,
+    pub repository: Repository,
+}
+
+/// The trimmed repository shape used in `installation_repositories`
+/// payloads. No default branch or language, so a full fetch is needed
+/// before the repo can be stored.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct InstallationRepository {
+    pub id: u64,
+    pub name: String,
+    pub full_name: String,
+    pub private: bool,
+}
+
+/// Sent when repositories are added to or removed from the App installation.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct InstallationRepositoriesEvent {
+    /// added | removed
+    pub action: String,
+    pub repositories_added: Vec<InstallationRepository>,
+    pub repositories_removed: Vec<InstallationRepository>,
+}


### PR DESCRIPTION
## Why

Per-repo webhooks can't tell us about a repo that didn't exist yet. Today that gap is papered over by the `webhooks-enforcer` cron on jobfather, which leaves a window of up to five minutes after `create repo` where cicd doesn't know the repo exists — exactly the window an agent hits when it creates, pushes, and deploys a project in one go.

A GitHub App installed with **All repositories** has one webhook for the whole account, receives `repository.created` the moment a repo exists, and needs no per-repo hook management. That retires the enforcer and the cron entirely rather than adding an MCP tool to race it.

## What changed

**`crab_ext.rs`** — `Octocrabs` is now a registry of per-installation clients rather than a `Vec<Octocrab>` of PATs.
- Installations are listed from `GET /app/installations` at startup and re-listed at the start of every owner scan.
- `crab_for(repo)` resolves by owner — an installation covers its account's repos — with a lazy `GET /repos/{o}/{r}/installation` fallback so installing the App on a new account works without a restart. No more per-call probe loop.
- `InstallationClient` derefs to `Octocrab` so call sites read the same, and holds an `Arc` so every clone shares one token cache (octocrab auto-refreshes installation tokens, but per-clone).
- The `OctocrabExt` trait is gone; `crab_for` is an inherent method.

**Webhooks** — two new events, both upserts:
- `repository` → upsert on `created` / `edited` / `renamed` / `transferred` / `publicized` / `privatized` / `unarchived`. `deleted`/`archived` keep their rows (no repo-removal path exists today).
- `installation_repositories.added` → fetch + upsert (the payload is a trimmed shape without default branch).

**Bootstrap** — owner scans iterate installations and use `GET /installation/repositories` (the `/user/repos` endpoint doesn't work for installation tokens). Per-repo scans resolve one installation up front. `GitRepo: TryFrom<octocrab::models::Repository>` replaces three copies of the same conversion.

**Config** — `GITHUB_APP_ID` + `GITHUB_APP_PRIVATE_KEY` replace `GITHUB_PATS`. Both unset still runs without GitHub access for local dev. Rate-limit gauges are labelled `installation="<account>"` instead of `token="1"`.

## Rollout plan

No deploy until reviewed. Every step below is reversible until step 6, and during steps 4–5 both delivery paths run side by side — every handler is an upsert, so double delivery is harmless.

### 0. Verify the two load-bearing assumptions first

Install the App (steps 1–2) on a single throwaway repo *before* touching cicd, and confirm via the proxy's `/recent-events` or the App's **Advanced → Recent Deliveries** tab:

- [ ] **`repository.created` arrives** for a repo created after an "All repositories" install. This is the whole premise.
- [ ] **`check_run` events for GitHub Actions runs arrive** with only `Checks: read`. cicd's entire build-status pipeline rides on these. I believe App webhooks receive check runs from all apps in the repo, but the Checks API has App-scoping subtleties and I'd rather see a delivery than assert it.

If (b) fails, stop here — the migration is dead as designed.

### 1. Create the App — `github.com/settings/apps/new`

| Setting | Value |
|---|---|
| Name | e.g. `coolkev-cicd` |
| Homepage | anything |
| Webhook → Active | ✅ |
| Webhook URL | the proxy's `/github` endpoint (same URL the per-repo hooks use today) |
| Webhook secret | the proxy's `WEBHOOK_SECRET` — the same value the enforcer writes into per-repo hooks, so no proxy change is needed |
| Repository permissions | **Metadata: Read** (mandatory), **Contents: Read**, **Checks: Read**, **Deployments: Read & write** |
| Subscribe to events | **Push**, **Check run**, **Delete**, **Repository** |
| Where can this App be installed? | Only on this account |

`installation` / `installation_repositories` are delivered to every App automatically and don't appear in the subscription list.

Then **Generate a private key** (downloads a `.pem`) and note the **App ID** from the top of the settings page.

### 2. Install it

App settings → **Install App** → your account → **All repositories**.

### 3. Secrets

Add two fields to the 1Password item `vaults/kube/items/cicd-auth` (already the source for the `cicd-auth` Secret via `OnePasswordItem`):

- `GITHUB_APP_ID` — the numeric App ID
- `GITHUB_APP_PRIVATE_KEY` — the full PEM, multi-line, including the `-----BEGIN RSA PRIVATE KEY-----` lines

**Leave `GITHUB_PATS` in place for now** — the currently-deployed image still reads it until this PR's image rolls.

Verify the operator synced it:
```
kubectl -n cicd get secret cicd-auth -o jsonpath='{.data.GITHUB_APP_ID}' | base64 -d
kubectl -n cicd get secret cicd-auth -o jsonpath='{.data.GITHUB_APP_PRIVATE_KEY}' | base64 -d | head -1
```

### 4. Deploy this PR

Startup logs should show:
```
GitHub App installation <id> on kj800x (all repositories)
GitHub App ready with 1 installation(s)
```
- [ ] Settings → Rate limits shows a `kj800x` row with a 5000/hr limit.
- [ ] Run a **Quick Scan** from Settings → Bootstrap; it should discover the same repo count as before.

### 5. Dual-run verification

Both the App webhook and the legacy per-repo hooks are delivering at this point.

- [ ] Create a throwaway repo. cicd logs `Repository kj800x/<name> created` within seconds and the row appears **before any push**.
- [ ] Push a commit to it; the commit and its build status show up as normal.
- [ ] Deploy something; the GitHub Deployments entries still appear on the repo (exercises `Deployments: RW`).
- [ ] Leave it running for a day or two and watch for `Error parsing ... event` in the logs.

### 6. Decommission the per-repo hooks

Order matters — the enforcer will recreate hooks every 5 minutes until it's stopped.

1. Remove the `webhooks-enforcer` JobTemplate (delete `.deploy/webhooks-enforcer/jobtemplate.yaml` and let cicd undeploy it, or `kubectl -n cicd delete jobtemplate webhooks-enforcer`).
2. Run `webhooks-enforcer remove` locally against the proxy URL to strip the per-repo hooks.
3. Delete `GITHUB_PATS` from the 1Password item and revoke the PATs at `github.com/settings/tokens`.
4. Archive the `webhooks-enforcer` repo.

### Rollback

Before step 6: redeploy the previous image; `GITHUB_PATS` is still in the Secret and the per-repo hooks are still delivering. After step 6: re-run the enforcer once to recreate hooks, then redeploy the previous image.

## Not in this PR / follow-ups

- **Grafana**: `cicd_github_rate_limit_*` label key changed from `token` to `installation`; any panel filtering on `token="1"` needs updating.
- **`installation.created`** (App installed on a second account) has no handler. It's picked up lazily on first `crab_for` for that owner, or by the next owner scan. Fine for a single-account setup.
- **Rate-limit headroom**: a personal-account installation is a flat 5000/hr, not the org-scaled limit. Actual request volume should drop (no probe loop, no enforcer sweep), but if headroom ever matters, an org install unlocks scaling.
- `repository.deleted` / `archived` don't remove rows — same as today's behaviour for deleted repos.

## Test plan

- [x] `cargo check`, `cargo clippy --all-targets` (7 warnings, all pre-existing from the 1.97 toolchain — identical count on `master`), `cargo test` (3 new unit tests in `crab_ext`)
- [ ] Steps 0, 4, 5 above against the live cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)
