### PR TITLE
Add webhook debug screen to settings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,8 @@ async fn start_http(
             .service(resource_logs_download)
             .service(web::watchdog_page)
             .service(web::watchdog_fragment)
+            .service(web::webhook_recent_list)
+            .service(web::webhook_recent_payload)
             .service(serve_static_file!("htmx.min.js"))
             .service(serve_static_file!("idiomorph.min.js"))
             .service(serve_static_file!("idiomorph-ext.min.js"))

--- a/src/res/styles.css
+++ b/src/res/styles.css
@@ -835,6 +835,75 @@ header {
     word-wrap: break-word;
     font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
   }
+
+  .webhook-events {
+    margin-top: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .webhook-event {
+    background: #f6f8fa;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+  }
+
+  .webhook-event-summary {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    padding: 8px 12px;
+    cursor: pointer;
+    font-size: 13px;
+    list-style-position: inside;
+  }
+
+  .webhook-event-summary::marker {
+    color: var(--secondary-text);
+  }
+
+  .webhook-event-time {
+    font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+    font-size: 12px;
+    color: var(--secondary-text);
+    white-space: nowrap;
+  }
+
+  .webhook-event-type {
+    font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--primary-blue);
+    white-space: nowrap;
+  }
+
+  .webhook-event-desc {
+    color: var(--text-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .webhook-payload {
+    border-top: 1px solid var(--border-color);
+    background: #fff;
+    padding: 8px 12px;
+    max-height: 480px;
+    overflow: auto;
+    font-size: 12px;
+    color: var(--secondary-text);
+  }
+
+  .webhook-payload-json {
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.4;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    color: var(--text-color);
+    font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  }
 }
 
 .index-page {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -12,6 +12,7 @@ mod resource_status;
 mod settings;
 pub mod team_prefs;
 mod watchdog;
+mod webhook_debug;
 
 pub use all_recent_builds::*;
 pub use bootstrap::*;
@@ -23,3 +24,4 @@ pub use resource_logs::*;
 pub use resource_status::*;
 pub use settings::*;
 pub use watchdog::*;
+pub use webhook_debug::*;

--- a/src/web/settings.rs
+++ b/src/web/settings.rs
@@ -108,6 +108,17 @@ fn render_sidebar(section: &str) -> Markup {
             {
                 "Bootstrap"
             }
+            a
+                class=(if section == "webhook-debug" { "settings-nav-link active" } else { "settings-nav-link" })
+                href="/settings?section=webhook-debug"
+                hx-get="/settings-fragment?section=webhook-debug"
+                hx-target="#settings-content"
+                hx-swap="morph:innerHTML"
+                hx-push-url="/settings?section=webhook-debug"
+                onclick="document.querySelectorAll('.settings-nav-link').forEach(l => l.classList.remove('active')); this.classList.add('active');"
+            {
+                "Webhook debug"
+            }
         }
     }
 }
@@ -178,6 +189,7 @@ pub async fn settings_fragment(
         "repo-visibility" => repo_visibility_fragment(req, pool).await,
         "rate-limits" => rate_limits_fragment().await,
         "bootstrap" => bootstrap_fragment().await,
+        "webhook-debug" => crate::web::webhook_debug::webhook_debug_fragment(),
         _ => team_visibility_fragment(req).await,
     }
 }

--- a/src/web/webhook_debug.rs
+++ b/src/web/webhook_debug.rs
@@ -1,0 +1,96 @@
+//! Settings > Webhook debug: shows the last few webhook events received in-process.
+
+use actix_web::web;
+use maud::{html, Markup};
+
+use crate::prelude::*;
+use crate::webhooks::recent::{self, RecordedWebhook, CAPACITY};
+
+pub fn webhook_debug_fragment() -> HttpResponse {
+    let markup = html! {
+        header {
+            h1 { "Webhook debug" }
+            div class="subtitle" {
+                (format!("The last {} webhook events received by this process. Held in memory only; cleared on restart.", CAPACITY))
+            }
+        }
+        div class="webhook-events"
+            id="webhook-events"
+            hx-get="/webhooks/recent"
+            hx-trigger="load, every 2s"
+            hx-swap="innerHTML"
+        { }
+    };
+
+    HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(markup.into_string())
+}
+
+fn render_event_row(event: &RecordedWebhook) -> Markup {
+    let id = format!("webhook-{}", event.id);
+    // hx-preserve keeps already-rendered rows (and their expanded state / loaded payload)
+    // across polls; rows are immutable so this is safe.
+    html! {
+        details
+            id=(id)
+            class="webhook-event"
+            hx-preserve="true"
+            hx-get=(format!("/webhooks/recent/{}", event.id))
+            hx-trigger="toggle once"
+            hx-target="find .webhook-payload"
+            hx-swap="innerHTML"
+        {
+            summary class="webhook-event-summary" {
+                span class="webhook-event-time" title=(event.received_at.to_rfc3339()) {
+                    (event.received_at.format("%Y-%m-%d %H:%M:%S UTC"))
+                }
+                span class="webhook-event-type" { (event.event_type) }
+                span class="webhook-event-desc" { (event.summary()) }
+            }
+            div class="webhook-payload" { "Loading…" }
+        }
+    }
+}
+
+#[get("/webhooks/recent")]
+pub async fn webhook_recent_list() -> impl Responder {
+    let events = recent::list();
+    let markup = html! {
+        @if events.is_empty() {
+            div class="empty-state" {
+                h2 { "No webhook events yet" }
+                p { "Events will appear here as they are received." }
+            }
+        } @else {
+            @for e in &events {
+                (render_event_row(e))
+            }
+        }
+    };
+
+    HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(markup.into_string())
+}
+
+#[get("/webhooks/recent/{id}")]
+pub async fn webhook_recent_payload(path: web::Path<u64>) -> impl Responder {
+    let id = path.into_inner();
+    let markup = match recent::get(id) {
+        Some(e) => {
+            let pretty =
+                serde_json::to_string_pretty(&e.payload).unwrap_or_else(|_| e.payload.to_string());
+            html! { pre class="webhook-payload-json" { (pretty) } }
+        }
+        None => html! {
+            div class="webhook-payload-missing" {
+                "This event is no longer retained (it has been evicted from the buffer)."
+            }
+        },
+    };
+
+    HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(markup.into_string())
+}

--- a/src/webhooks/manager.rs
+++ b/src/webhooks/manager.rs
@@ -167,6 +167,7 @@ impl WebhookManager {
 
     async fn process_event(&self, event: WebhookEvent) -> Result<(), anyhow::Error> {
         log::debug!("Received event: {}", event.event_type);
+        crate::webhooks::recent::record(&event);
 
         match event.event_type.as_str() {
             "push" => match serde_json::from_value::<PushEvent>(event.payload.clone()) {

--- a/src/webhooks/mod.rs
+++ b/src/webhooks/mod.rs
@@ -11,6 +11,7 @@ pub mod log;
 pub mod manager;
 pub mod metrics;
 pub mod models;
+pub mod recent;
 pub mod util;
 
 #[async_trait]

--- a/src/webhooks/recent.rs
+++ b/src/webhooks/recent.rs
@@ -1,0 +1,235 @@
+//! In-memory ring buffer of recently received webhook events, for debugging.
+//!
+//! Nothing here is persisted; the buffer is reset on restart.
+
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
+
+use chrono::{DateTime, Utc};
+
+use crate::webhooks::models::WebhookEvent;
+
+/// Maximum number of events retained.
+pub const CAPACITY: usize = 20;
+
+#[derive(Debug, Clone)]
+pub struct RecordedWebhook {
+    /// Monotonic id, unique for the lifetime of the process.
+    pub id: u64,
+    pub received_at: DateTime<Utc>,
+    pub event_type: String,
+    pub payload: serde_json::Value,
+}
+
+impl RecordedWebhook {
+    /// A short, human-readable one-liner describing the event, e.g.
+    /// `push to kj800x/my-repo (main)` or `check_run completed · kj800x/my-repo · build`.
+    pub fn summary(&self) -> String {
+        let p = &self.payload;
+        let repo = p
+            .pointer("/repository/full_name")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let action = p.get("action").and_then(|v| v.as_str());
+
+        match self.event_type.as_str() {
+            "push" => {
+                let git_ref = p.get("ref").and_then(|v| v.as_str()).map(|r| {
+                    r.trim_start_matches("refs/heads/")
+                        .trim_start_matches("refs/tags/")
+                });
+                let mut s = String::from("push");
+                if let Some(repo) = &repo {
+                    s.push_str(&format!(" to {}", repo));
+                }
+                if let Some(r) = git_ref {
+                    s.push_str(&format!(" ({})", r));
+                }
+                if p.get("deleted").and_then(|v| v.as_bool()) == Some(true) {
+                    s.push_str(" [deleted]");
+                }
+                s
+            }
+            "delete" => {
+                let git_ref = p.get("ref").and_then(|v| v.as_str());
+                let mut s = String::from("delete");
+                if let Some(r) = git_ref {
+                    s.push_str(&format!(" {}", r));
+                }
+                if let Some(repo) = &repo {
+                    s.push_str(&format!(" in {}", repo));
+                }
+                s
+            }
+            "check_run" | "check_suite" => {
+                let mut parts: Vec<String> = vec![self.event_type.clone()];
+                if let Some(a) = action {
+                    parts[0] = format!("{} {}", self.event_type, a);
+                }
+                if let Some(repo) = &repo {
+                    parts.push(repo.clone());
+                }
+                if let Some(name) = p.pointer("/check_run/name").and_then(|v| v.as_str()) {
+                    parts.push(name.to_string());
+                }
+                if let Some(branch) = p
+                    .pointer("/check_suite/head_branch")
+                    .and_then(|v| v.as_str())
+                {
+                    parts.push(branch.to_string());
+                }
+                if let Some(c) = p
+                    .pointer("/check_run/conclusion")
+                    .or_else(|| p.pointer("/check_suite/conclusion"))
+                    .and_then(|v| v.as_str())
+                {
+                    parts.push(c.to_string());
+                }
+                parts.join(" · ")
+            }
+            "installation_repositories" => {
+                let added = p
+                    .get("repositories_added")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let removed = p
+                    .get("repositories_removed")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                format!(
+                    "installation_repositories {} · +{} / -{}",
+                    action.unwrap_or(""),
+                    added,
+                    removed
+                )
+                .trim()
+                .to_string()
+            }
+            other => {
+                let mut s = other.to_string();
+                if let Some(a) = action {
+                    s.push_str(&format!(" {}", a));
+                }
+                if let Some(repo) = &repo {
+                    s.push_str(&format!(" · {}", repo));
+                }
+                s
+            }
+        }
+    }
+}
+
+struct Store {
+    next_id: u64,
+    events: VecDeque<RecordedWebhook>,
+}
+
+static STORE: OnceLock<Mutex<Store>> = OnceLock::new();
+
+fn store() -> &'static Mutex<Store> {
+    STORE.get_or_init(|| {
+        Mutex::new(Store {
+            next_id: 1,
+            events: VecDeque::with_capacity(CAPACITY + 1),
+        })
+    })
+}
+
+/// Record a received webhook event, evicting the oldest if over capacity.
+pub fn record(event: &WebhookEvent) {
+    let Ok(mut s) = store().lock() else {
+        log::warn!("Recent webhook store lock poisoned; not recording event");
+        return;
+    };
+    let id = s.next_id;
+    s.next_id += 1;
+    s.events.push_front(RecordedWebhook {
+        id,
+        received_at: Utc::now(),
+        event_type: event.event_type.clone(),
+        payload: event.payload.clone(),
+    });
+    while s.events.len() > CAPACITY {
+        s.events.pop_back();
+    }
+}
+
+/// All retained events, newest first.
+pub fn list() -> Vec<RecordedWebhook> {
+    store()
+        .lock()
+        .map(|s| s.events.iter().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// Look up a single retained event by id.
+pub fn get(id: u64) -> Option<RecordedWebhook> {
+    store()
+        .lock()
+        .ok()
+        .and_then(|s| s.events.iter().find(|e| e.id == id).cloned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ev(event_type: &str, payload: serde_json::Value) -> RecordedWebhook {
+        RecordedWebhook {
+            id: 0,
+            received_at: Utc::now(),
+            event_type: event_type.to_string(),
+            payload,
+        }
+    }
+
+    #[test]
+    fn push_summary() {
+        let e = ev(
+            "push",
+            json!({"ref": "refs/heads/main", "repository": {"full_name": "kj800x/my-repo"}}),
+        );
+        assert_eq!(e.summary(), "push to kj800x/my-repo (main)");
+    }
+
+    #[test]
+    fn check_run_summary() {
+        let e = ev(
+            "check_run",
+            json!({
+                "action": "completed",
+                "repository": {"full_name": "kj800x/my-repo"},
+                "check_run": {"name": "build", "conclusion": "success"}
+            }),
+        );
+        assert_eq!(
+            e.summary(),
+            "check_run completed · kj800x/my-repo · build · success"
+        );
+    }
+
+    #[test]
+    fn unknown_summary_without_repo() {
+        let e = ev("ping", json!({}));
+        assert_eq!(e.summary(), "ping");
+    }
+
+    #[test]
+    fn ring_buffer_evicts_oldest() {
+        for i in 0..(CAPACITY + 5) {
+            record(&WebhookEvent {
+                event_type: format!("t{}", i),
+                payload: json!({}),
+            });
+        }
+        let all = list();
+        assert_eq!(all.len(), CAPACITY);
+        // newest first
+        assert_eq!(all[0].event_type, format!("t{}", CAPACITY + 4));
+        assert!(get(all[0].id).is_some());
+        assert!(all.windows(2).all(|w| w[0].id > w[1].id));
+    }
+}


### PR DESCRIPTION
## Summary

- New **Settings → Webhook debug** section showing the last 20 webhook events received by the process.
- Events are held in an in-memory ring buffer (`src/webhooks/recent.rs`), recorded at the top of `WebhookManager::process_event` so unknown/unparseable-payload events are captured too. Nothing is persisted; the buffer is cleared on restart.
- Each row is collapsed by default and shows timestamp (UTC), event type, and an abbreviated summary:
  - `push to kj800x/my-repo (main)`
  - `check_run completed · kj800x/my-repo · build · success`
  - `installation_repositories added · +2 / -0`
  - falls back to `<type> <action> · <repo>` for anything else
- Clicking a row loads the full pretty-printed JSON payload from `GET /webhooks/recent/{id}`.
- The list polls `GET /webhooks/recent` every 2s like the other settings panels. Rows use `hx-preserve` so expanded rows and their loaded payloads survive polls (rows are immutable, so this is safe).

## Test plan

- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo test recent` — summary formatting + ring-buffer eviction/ordering tests pass
- [ ] Deploy, open `/settings?section=webhook-debug`, push to a repo, confirm the row appears within ~2s and expands to show the payload
- [ ] Confirm an expanded row stays expanded across polls

🤖 Generated with [Claude Code](https://claude.com/claude-code)