### PR TITLE
Orphan deploy configs when their config or artifact repo goes away

### DIFF
--- a/src/db/deploy_config.rs
+++ b/src/db/deploy_config.rs
@@ -39,6 +39,23 @@ impl DeployConfig {
         Ok(deploy_configs)
     }
 
+    /// Configs that reference `repo_id` as either their config repo or their
+    /// artifact repo.
+    pub fn get_by_any_repo_id(
+        repo_id: u64,
+        conn: &PooledConnection<SqliteConnectionManager>,
+    ) -> AppResult<Vec<Self>> {
+        let mut deploy_configs = Vec::new();
+        let mut stmt = conn.prepare("SELECT name, team, kind, config_repo_id, artifact_repo_id, active FROM deploy_config WHERE config_repo_id = ?1 OR artifact_repo_id = ?1")?;
+        let mut rows = stmt.query(params![repo_id])?;
+
+        while let Some(row) = rows.next()? {
+            deploy_configs.push(DeployConfig::from_row(row)?);
+        }
+
+        Ok(deploy_configs)
+    }
+
     pub fn upsert(
         deploy_config: &DeployConfig,
         conn: &PooledConnection<SqliteConnectionManager>,

--- a/src/kubernetes/deploy_config.rs
+++ b/src/kubernetes/deploy_config.rs
@@ -107,6 +107,27 @@ impl DeployConfig {
             .unwrap_or(false)
     }
 
+    /// Whether this config depends on `repo`, either as the config repo
+    /// (where its `.deploy/` manifests live) or as the artifact repo (where
+    /// its image is built). GitHub owner and repo names are
+    /// case-insensitive, so the comparison is too.
+    pub fn references_repo(&self, repo: &Repository) -> bool {
+        let same = |owner: &str, name: &str| {
+            owner.eq_ignore_ascii_case(&repo.owner) && name.eq_ignore_ascii_case(&repo.repo)
+        };
+
+        let config = &self.spec.spec.config;
+        if same(&config.owner, &config.repo) {
+            return true;
+        }
+
+        self.spec
+            .spec
+            .artifact
+            .as_ref()
+            .is_some_and(|artifact| same(&artifact.owner, &artifact.repo))
+    }
+
     pub fn supports_bounce(&self) -> bool {
         self.resource_specs().iter().any(|spec| {
             spec.get("kind")
@@ -332,5 +353,61 @@ impl DeployConfig {
         if !owner_ref_exists {
             owner_refs.push(self.child_owner_reference());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repo(owner: &str, repo: &str) -> Repository {
+        Repository {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+        }
+    }
+
+    fn config(config_repo: Repository, artifact_repo: Option<Repository>) -> DeployConfig {
+        DeployConfig::new(
+            "test",
+            DeployConfigSpec {
+                spec: DeployConfigSpecFields {
+                    team: "test".to_string(),
+                    kind: "service".to_string(),
+                    artifact: artifact_repo.map(|r| RepositoryBranch {
+                        owner: r.owner,
+                        repo: r.repo,
+                        branch: "master".to_string(),
+                    }),
+                    config: config_repo,
+                    specs: vec![],
+                },
+            },
+        )
+    }
+
+    #[test]
+    fn references_config_repo() {
+        let dc = config(repo("kj800x", "app"), None);
+        assert!(dc.references_repo(&repo("kj800x", "app")));
+        assert!(!dc.references_repo(&repo("kj800x", "other")));
+        assert!(!dc.references_repo(&repo("someone-else", "app")));
+    }
+
+    #[test]
+    fn references_artifact_repo() {
+        let dc = config(
+            repo("sqrt10pi", "wr-rs"),
+            Some(repo("kj800x", "site-server")),
+        );
+        assert!(dc.references_repo(&repo("sqrt10pi", "wr-rs")));
+        assert!(dc.references_repo(&repo("kj800x", "site-server")));
+        assert!(!dc.references_repo(&repo("kj800x", "wr-rs")));
+    }
+
+    #[test]
+    fn references_repo_is_case_insensitive() {
+        let dc = config(repo("kj800x", "Hello-World"), None);
+        assert!(dc.references_repo(&repo("KJ800X", "hello-world")));
     }
 }

--- a/src/kubernetes/webhook_handlers.rs
+++ b/src/kubernetes/webhook_handlers.rs
@@ -137,6 +137,64 @@ async fn delete_deploy_config(
     Ok(())
 }
 
+/// Handle a repository that can no longer be used: deleted, archived, or
+/// removed from the GitHub App installation.
+///
+/// Every DeployConfig that references `repo` as either its config repo or
+/// its artifact repo is affected: without the config repo there is nothing
+/// to sync from, and without the artifact repo there is nothing to build or
+/// deploy. Deployed configs are marked orphaned (so only undeploy is
+/// offered); undeployed ones are deleted outright, matching what happens
+/// when a push removes a `.deploy/` file.
+///
+/// Each config is handled independently so one failure doesn't hide the
+/// rest. Returns the names of the configs that were updated.
+pub async fn orphan_deploy_configs_for_repo(
+    client: &Client,
+    repo: &Repository,
+    reason: &str,
+) -> Result<Vec<String>, Error> {
+    let api: Api<DeployConfig> = Api::all(client.clone());
+    let deploy_configs = match api.list(&Default::default()).await {
+        Ok(list) => list.items,
+        Err(e) => {
+            log::error!("Failed to list DeployConfigs:\n{}", format_error_chain(&e));
+            return Err(Error::Kube(e));
+        }
+    };
+
+    let mut affected = Vec::new();
+    let mut first_error = None;
+
+    for dc in deploy_configs.iter().filter(|dc| dc.references_repo(repo)) {
+        let name = dc.name_any();
+        log::info!(
+            "DeployConfig {} references {}/{}, which was {}",
+            name,
+            repo.owner,
+            repo.repo,
+            reason
+        );
+
+        match delete_deploy_config(client, dc).await {
+            Ok(()) => affected.push(name),
+            Err(e) => {
+                log::error!(
+                    "Failed to orphan DeployConfig {}:\n{}",
+                    name,
+                    format_error_chain(&e)
+                );
+                first_error.get_or_insert(e);
+            }
+        }
+    }
+
+    match first_error {
+        Some(e) => Err(e),
+        None => Ok(affected),
+    }
+}
+
 pub async fn update_deploy_configs_by_defining_repo(
     client: &Client,
     final_deploy_configs: &[DeployConfig],

--- a/src/webhooks/config_sync.rs
+++ b/src/webhooks/config_sync.rs
@@ -18,10 +18,16 @@ use crate::{
     kubernetes::{
         deploy_config::{DeployConfig, DeployConfigSpec, DeployConfigSpecFields},
         repo::RepositoryBranch,
-        webhook_handlers::update_deploy_configs_by_defining_repo,
+        webhook_handlers::{
+            orphan_deploy_configs_for_repo, update_deploy_configs_by_defining_repo,
+        },
         Repository,
     },
-    webhooks::{models::PushEvent, util::extract_branch_name, WebhookHandler},
+    webhooks::{
+        models::{InstallationRepositoriesEvent, PushEvent, RepositoryEvent},
+        util::extract_branch_name,
+        WebhookHandler,
+    },
 };
 
 pub struct ConfigSyncHandler {
@@ -37,6 +43,56 @@ impl ConfigSyncHandler {
             client,
             octocrabs,
         }
+    }
+
+    /// A repository we can no longer read from or build: deleted, archived,
+    /// or removed from the App installation. Any deploy config it defines
+    /// (config repo) or builds for (artifact repo) is orphaned.
+    ///
+    /// `repo_id` is only used to retire the database rows for configs this
+    /// repo *defines*; configs that merely build from it are still defined by
+    /// a live repo and keep their rows.
+    async fn handle_repo_gone(
+        &self,
+        owner: &str,
+        name: &str,
+        repo_id: u64,
+        reason: &str,
+    ) -> Result<(), anyhow::Error> {
+        {
+            let conn = self.pool.get()?;
+            for db_config in DbDeployConfig::get_by_config_repo_id(repo_id, &conn)? {
+                if db_config.active {
+                    DbDeployConfig::mark_inactive(&db_config.name, &conn)?;
+                }
+            }
+        }
+
+        let repository = Repository {
+            owner: owner.to_string(),
+            repo: name.to_string(),
+        };
+        let affected = orphan_deploy_configs_for_repo(&self.client, &repository, reason).await?;
+
+        if affected.is_empty() {
+            log::debug!(
+                "Repository {}/{} {}, no deploy configs reference it",
+                owner,
+                name,
+                reason
+            );
+        } else {
+            log::info!(
+                "Repository {}/{} {}, orphaned {} deploy config(s): {}",
+                owner,
+                name,
+                reason,
+                affected.len(),
+                affected.join(", ")
+            );
+        }
+
+        Ok(())
     }
 }
 
@@ -156,6 +212,59 @@ impl WebhookHandler for ConfigSyncHandler {
         }
 
         Ok(())
+    }
+
+    async fn handle_repository(&self, event: RepositoryEvent) -> Result<(), anyhow::Error> {
+        // `unarchived` is deliberately not handled here: clearing the orphan
+        // flag happens on the next push to the config repo's default branch,
+        // which re-syncs the config and resets `status.orphaned`.
+        match event.action.as_str() {
+            "deleted" | "archived" => {
+                self.handle_repo_gone(
+                    &event.repository.owner.login,
+                    &event.repository.name,
+                    event.repository.id,
+                    &event.action,
+                )
+                .await
+            }
+            _ => Ok(()),
+        }
+    }
+
+    async fn handle_installation_repositories(
+        &self,
+        event: InstallationRepositoriesEvent,
+    ) -> Result<(), anyhow::Error> {
+        if event.action != "removed" {
+            return Ok(());
+        }
+
+        // Best-effort per repo so one failure doesn't hide the others.
+        let mut first_error = None;
+        for removed in &event.repositories_removed {
+            let Some((owner, name)) = removed.full_name.split_once('/') else {
+                log::warn!("Malformed repository full_name: {}", removed.full_name);
+                continue;
+            };
+
+            if let Err(e) = self
+                .handle_repo_gone(owner, name, removed.id, "removed from the installation")
+                .await
+            {
+                log::error!(
+                    "Failed to orphan deploy configs for {}: {:#}",
+                    removed.full_name,
+                    e
+                );
+                first_error.get_or_insert(e);
+            }
+        }
+
+        match first_error {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
     }
 }
 

--- a/src/webhooks/config_sync.rs
+++ b/src/webhooks/config_sync.rs
@@ -46,12 +46,9 @@ impl ConfigSyncHandler {
     }
 
     /// A repository we can no longer read from or build: deleted, archived,
-    /// or removed from the App installation. Any deploy config it defines
-    /// (config repo) or builds for (artifact repo) is orphaned.
-    ///
-    /// `repo_id` is only used to retire the database rows for configs this
-    /// repo *defines*; configs that merely build from it are still defined by
-    /// a live repo and keep their rows.
+    /// or removed from the App installation. Any deploy config that uses it
+    /// as either its config repo or its artifact repo is orphaned, and the
+    /// matching database rows are retired.
     async fn handle_repo_gone(
         &self,
         owner: &str,
@@ -61,7 +58,7 @@ impl ConfigSyncHandler {
     ) -> Result<(), anyhow::Error> {
         {
             let conn = self.pool.get()?;
-            for db_config in DbDeployConfig::get_by_config_repo_id(repo_id, &conn)? {
+            for db_config in DbDeployConfig::get_by_any_repo_id(repo_id, &conn)? {
                 if db_config.active {
                     DbDeployConfig::mark_inactive(&db_config.name, &conn)?;
                 }

--- a/src/webhooks/database.rs
+++ b/src/webhooks/database.rs
@@ -220,8 +220,9 @@ impl WebhookHandler for DatabaseHandler {
                     payload.action
                 );
             }
-            // Deleted and archived repos keep their rows: there is no repo
-            // removal path today, and their history stays useful.
+            // Deleted and archived repos keep their rows: their history stays
+            // useful. Orphaning the deploy configs that reference them is
+            // ConfigSyncHandler's job.
             _ => log::debug!(
                 "Ignoring repository {} for {}/{}",
                 payload.action,
@@ -239,7 +240,8 @@ impl WebhookHandler for DatabaseHandler {
     ) -> Result<(), anyhow::Error> {
         log::debug!("Received installation_repositories event:\n{:#?}", payload);
 
-        // Removal keeps rows for the same reason repository.deleted does.
+        // Removal keeps rows for the same reason repository.deleted does;
+        // ConfigSyncHandler orphans the affected deploy configs.
         if payload.action != "added" {
             return Ok(());
         }


### PR DESCRIPTION
## Summary

Found while testing webhook pickup for new repos: deleting `kj800x/hello-world-2` via the GitHub UI produced `repository.deleted` and `installation_repositories.removed` events (both visible on the webhook debug screen), but the controller did nothing with them. `DatabaseHandler` ignores both actions at debug level, and `ConfigSyncHandler` only implemented `handle_push`, so the only path that sets `status.orphaned` (`delete_deploy_config`) was unreachable. The config stayed `deployed`, `orphaned: false`, and the UI/MCP kept offering `deploy`/`bounce` against a repo that no longer existed.

**Either the artifact repo or the config repo going away counts as orphaned** — without the config repo there's nothing to sync from, without the artifact repo there's nothing to build. Both are treated identically everywhere in this PR.

- `DeployConfig::references_repo(&Repository)` — true if the repo is the config repo **or** the artifact repo (case-insensitive, since GitHub names are).
- `orphan_deploy_configs_for_repo` in `webhook_handlers.rs` — lists all DeployConfigs, filters by `references_repo`, and runs each through the existing `delete_deploy_config` (deployed → `status.orphaned: true`; undeployed → CRD deleted). Each config is handled independently so one failure doesn't hide the rest; the first error is returned after the loop.
- `ConfigSyncHandler` now overrides `handle_repository` (`deleted` | `archived`) and `handle_installation_repositories` (`removed`). Both route through `handle_repo_gone`, which also marks the SQLite `deploy_config` rows inactive for any config whose `config_repo_id` **or** `artifact_repo_id` matches (new `DbDeployConfig::get_by_any_repo_id`). That `active` column is currently write-only bookkeeping — nothing reads it — so this is for consistency with the push path, not behavior.
- Updated the stale "there is no repo removal path today" comments in `database.rs`.

Deliberately **not** handled: `unarchived` / re-`added`. Un-orphaning already happens on the next push to the config repo's default branch (`update_deploy_config` resets `orphaned: false`), which is the same path that clears it today when a `.deploy/` file is restored.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets` (only the 4 pre-existing warnings on master), `cargo test` (15 passed, 3 new for `references_repo` incl. an artifact-repo-only match)
- [ ] After deploy: `hello-world-2` is still deployed in `home-sensors` and its repo is already gone — re-triggering isn't possible without a repo, so either create + delete a throwaway repo with a `.deploy/` config and confirm it flips to `orphaned: true` within a few seconds, or archive/unarchive one of the undeployed test repos and confirm the CRD is deleted
- [ ] Archive an artifact-only repo (one referenced by a config in a different repo) and confirm the dependent config goes orphaned
- [ ] Confirm the orphaned config in the UI only offers undeploy, and that undeploy fully removes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
